### PR TITLE
Fix: Achievement creation 400 error from schema mismatch

### DIFF
--- a/apps/web/app/api/achievements/route.ts
+++ b/apps/web/app/api/achievements/route.ts
@@ -24,6 +24,9 @@ const achievementSchema = z.object({
   impactSource: z.enum(['user', 'llm']).optional(),
   impactUpdatedAt: z.string().datetime().optional(),
   source: z.enum(['manual', 'llm']).optional(),
+  userMessageId: z.string().uuid().optional().nullable(),
+  standupDocumentId: z.string().uuid().optional().nullable(),
+  isArchived: z.boolean().optional(),
 });
 
 // GET /api/achievements
@@ -131,8 +134,9 @@ export async function POST(req: NextRequest) {
         ? new Date(result.data.impactUpdatedAt)
         : new Date(),
       source: result.data.source ?? 'manual',
-      isArchived: false,
-      userMessageId: null,
+      isArchived: result.data.isArchived ?? false,
+      userMessageId: result.data.userMessageId ?? null,
+      standupDocumentId: result.data.standupDocumentId ?? null,
       summary: result.data.summary ?? null,
       details: result.data.details ?? null,
       companyId: finalCompanyId ?? null,


### PR DESCRIPTION
## Summary

Fixes critical bug where the Quick Add Achievement feature fails with a 400 Bad Request error.

## Problem

The client sends `userMessageId`, `standupDocumentId`, and `isArchived` fields in the achievement creation payload, but the API's Zod validation schema was rejecting these fields as unexpected, causing all achievement creation attempts to fail.

## Solution

Updated the API validation schema in `apps/web/app/api/achievements/route.ts` to:
1. Accept the three missing optional fields in the Zod schema
2. Use client-provided values with sensible defaults in the data preparation logic

## Testing

- ✅ All 121 tests pass
- ✅ Build succeeds with no TypeScript errors
- ✅ Linting and formatting checks pass
- ✅ Maintains backward compatibility (all fields optional with defaults)

## Impact

- **Priority**: P0 (blocks core functionality)
- **Risk**: Low (single file, localized change)
- **Backward Compatibility**: Fully maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)