### PR TITLE
fix: update CLI default API URL to app.bragdoc.ai

### DIFF
--- a/.changeset/fix-cli-default-url.md
+++ b/.changeset/fix-cli-default-url.md
@@ -1,0 +1,5 @@
+---
+'@bragdoc/cli': patch
+---
+
+Fix default API URL to point to https://app.bragdoc.ai instead of https://www.bragdoc.ai

--- a/packages/cli/src/config/paths.ts
+++ b/packages/cli/src/config/paths.ts
@@ -74,5 +74,5 @@ export function getConfigPath(): string {
  * Get the API base URL from config or use default
  */
 export function getApiBaseUrl(config: BragdocConfig): string {
-  return config.settings.apiBaseUrl || 'https://www.bragdoc.ai';
+  return config.settings.apiBaseUrl || 'https://app.bragdoc.ai';
 }


### PR DESCRIPTION
## Summary

- Fixed CLI default API URL from `https://www.bragdoc.ai` to `https://app.bragdoc.ai`
- Added changeset entry for patch version bump

## Context

The production app has moved to app.bragdoc.ai, but the CLI was still defaulting to www.bragdoc.ai, causing authentication and API calls to fail for users without a custom apiBaseUrl configured.

## Changes

- Updated `packages/cli/src/config/paths.ts` to use correct default URL
- Created changeset for tracking the version bump

## Test plan

- [ ] Verify CLI login command works with default configuration
- [ ] Confirm existing users with custom apiBaseUrl are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)