### PR TITLE
feat: add comprehensive beta messaging to marketing site

### DIFF
--- a/.claude/docs/tech/frontend-patterns.md
+++ b/.claude/docs/tech/frontend-patterns.md
@@ -1387,12 +1387,318 @@ posthog.init(key, {
 2. See events appear within 30 seconds
 3. Verify event properties are correct
 
+## Beta Messaging Patterns (Marketing Site)
+
+**Context:** These patterns were established during the marketing site beta banners implementation (October 2025) to communicate open beta status, free features, and future pricing clearly to users.
+
+### Beta Banner Pattern
+
+**Purpose:** Prominent full-width banner to announce beta status and special offers.
+
+**Location:** `apps/marketing/components/pricing/beta-banner.tsx`
+
+**Pattern:**
+```tsx
+import { Sparkles } from 'lucide-react';
+
+export function BetaBanner() {
+  return (
+    <div className="bg-gradient-to-r from-purple-600 to-purple-500 dark:from-purple-700 dark:to-purple-600 text-white py-4">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-center gap-3 text-center">
+          <Sparkles className="size-5 shrink-0" />
+          <div>
+            <p className="font-bold text-base sm:text-lg">
+              OPEN BETA - All Features Currently{' '}
+              <span className="text-green-300">FREE</span>
+            </p>
+            <p className="text-sm sm:text-base opacity-95">
+              Sign up now and get <strong>one year free</strong> when we launch paid plans
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Usage:**
+```tsx
+// In page.tsx
+import { BetaBanner } from '@/components/pricing/beta-banner';
+
+export default function PricingPage() {
+  return (
+    <>
+      <Header />
+      <BetaBanner />
+      <main>{/* ... */}</main>
+    </>
+  );
+}
+```
+
+**Design Guidelines:**
+- **Gradient background:** `from-purple-600 to-purple-500` (brand colors)
+- **White text** for high contrast
+- **Green emphasis** (`text-green-300`) for "FREE" keyword
+- **Bold text** for main message and key phrases
+- **Icon:** Sparkles icon to draw attention
+- **Responsive:** Smaller text on mobile, larger on desktop
+- **Centered:** Full-width container with centered content
+
+### Strikethrough Pricing Pattern
+
+**Purpose:** Display future pricing while emphasizing current free status.
+
+**Pattern:**
+```tsx
+<div className="text-center mb-4">
+  <Badge className="text-2xl px-6 py-2 bg-green-600 dark:bg-green-500 text-white">
+    FREE During Beta
+  </Badge>
+</div>
+
+<div className="text-center">
+  <div className="flex items-baseline justify-center gap-2 text-muted-foreground">
+    <span className="text-3xl font-semibold line-through opacity-60">$4.99</span>
+    <span className="text-base line-through opacity-60">/month</span>
+  </div>
+  <p className="text-xs text-muted-foreground mt-1">
+    Future price after beta
+  </p>
+</div>
+```
+
+**Design Guidelines:**
+- **Large "FREE" badge:** 2xl text size, green background
+- **Strikethrough pricing:** `line-through opacity-60` for muted appearance
+- **Muted text color:** `text-muted-foreground` to de-emphasize future pricing
+- **Label below:** "Future price after beta" to clarify pricing timeline
+- **Semantic hierarchy:** FREE > Strikethrough > Label (decreasing emphasis)
+
+### Beta Badge Pattern
+
+**Purpose:** Subtle indicator for features still in beta.
+
+**Location:** `apps/marketing/components/features-page-client.tsx`
+
+**Pattern:**
+```tsx
+import { Badge } from '@/components/ui/badge';
+
+interface Feature {
+  heading: string;
+  isBeta?: boolean;
+  // ... other props
+}
+
+export function FeatureCard({ feature }: { feature: Feature }) {
+  return (
+    <div>
+      <h2 className="text-2xl sm:text-3xl font-bold flex items-center gap-2 flex-wrap">
+        {feature.heading}
+        {feature.isBeta && (
+          <Badge variant="secondary" className="text-xs">
+            Beta
+          </Badge>
+        )}
+      </h2>
+      {/* ... */}
+    </div>
+  );
+}
+```
+
+**Design Guidelines:**
+- **Badge variant:** `secondary` for subtle, muted appearance
+- **Small size:** `text-xs` to avoid overwhelming the heading
+- **Inline placement:** Next to heading using flexbox
+- **Optional property:** `isBeta?: boolean` flag for maintainability
+- **Flex wrap:** Ensures badge wraps on mobile if needed
+- **When to use:** Only for actual beta features (not just new features)
+
+### Promotional Callout Pattern
+
+**Purpose:** Highlight special offers or benefits for beta users.
+
+**Pattern:**
+```tsx
+<div className="w-full p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
+  <p className="text-sm font-medium text-green-700 dark:text-green-400 text-center">
+    🎁 Sign up during beta → Get one year FREE when we launch
+  </p>
+</div>
+```
+
+**Design Guidelines:**
+- **Green color scheme:** Positive, benefit-oriented messaging
+- **Light background:** `bg-green-50` in light mode, `bg-green-950/30` in dark
+- **Border:** Subtle green border for definition
+- **Emoji:** Gift emoji (🎁) adds visual interest
+- **Center alignment:** For promotional messaging
+- **Font weight:** Medium for emphasis without being bold
+- **Dark mode:** Lower opacity background to avoid overwhelming
+
+### Color Scheme Guidelines
+
+**Beta Messaging Colors:**
+
+| Context | Light Mode | Dark Mode | Purpose |
+|---------|-----------|-----------|---------|
+| FREE emphasis | `text-green-600` | `text-green-500` | Positive, current benefit |
+| Beta banner background | `from-purple-600 to-purple-500` | `from-purple-700 to-purple-600` | Brand colors, high visibility |
+| Strikethrough pricing | `text-muted-foreground line-through opacity-60` | Same | De-emphasized future pricing |
+| Promotional box | `bg-green-50 border-green-200` | `bg-green-950/30 border-green-800` | Special offer highlight |
+| Beta badge | `variant="secondary"` | Same | Subtle information badge |
+
+### Responsive Considerations
+
+**Mobile (375px - 767px):**
+- Beta banner text: `text-base` main, `text-sm` secondary
+- Flex wrap on headings with badges
+- Full-width promotional callouts
+- Stack pricing cards vertically
+
+**Tablet (768px - 1023px):**
+- Beta banner text: `sm:text-lg` main, `sm:text-base` secondary
+- Pricing cards may stack or show 2-up depending on content
+- Badges remain inline with headings
+
+**Desktop (1024px+):**
+- Full text sizes
+- Pricing cards show side-by-side
+- Maximum visual impact for beta messaging
+
+### When to Use These Patterns
+
+**Use Beta Banner when:**
+- Announcing product-wide beta status
+- Communicating time-limited offers
+- Driving action (sign-ups, early adoption)
+
+**Use Strikethrough Pricing when:**
+- Showing future pricing while emphasizing current free access
+- Providing price transparency during beta
+- Balancing "free now" with "paid later" messaging
+
+**Use Beta Badges when:**
+- Marking individual features as beta
+- Communicating feature stability/maturity
+- Setting expectations for feature completeness
+
+**Use Promotional Callouts when:**
+- Highlighting special beta user benefits
+- Emphasizing time-sensitive offers
+- Drawing attention to value propositions
+
+### Example: Full Pricing Page Integration
+
+```tsx
+import { BetaBanner } from '@/components/pricing/beta-banner';
+import { Badge } from '@/components/ui/badge';
+
+export default function PricingPage() {
+  return (
+    <>
+      <Header />
+      <BetaBanner />
+
+      <main className="pt-16">
+        <PricingHeader />
+
+        <div className="grid md:grid-cols-2 gap-8">
+          {/* Free Account */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Free Account</CardTitle>
+              <CardDescription>
+                Always free, even after beta
+              </CardDescription>
+            </CardHeader>
+            {/* ... */}
+          </Card>
+
+          {/* Full Account */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Full Account</CardTitle>
+              <CardDescription>
+                Everything you need - currently FREE during open beta
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {/* Strikethrough Pricing Pattern */}
+              <div className="text-center mb-4">
+                <Badge className="text-2xl px-6 py-2 bg-green-600 text-white">
+                  FREE During Beta
+                </Badge>
+              </div>
+              <div className="text-center">
+                <div className="flex items-baseline justify-center gap-2 text-muted-foreground">
+                  <span className="text-3xl font-semibold line-through opacity-60">
+                    $4.99
+                  </span>
+                  <span className="text-base line-through opacity-60">/month</span>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Future price after beta
+                </p>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3">
+              {/* Promotional Callout Pattern */}
+              <div className="w-full p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
+                <p className="text-sm font-medium text-green-700 dark:text-green-400 text-center">
+                  🎁 Sign up during beta → Get one year FREE when we launch
+                </p>
+              </div>
+              <Button size="lg" className="w-full">
+                Get Started Free
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      </main>
+    </>
+  );
+}
+```
+
+### Accessibility Notes
+
+- **Color contrast:** All green text meets WCAG AA standards
+- **Strikethrough clarity:** Combined with "Future price" label for screen readers
+- **Badge semantics:** Uses proper Badge component with ARIA attributes
+- **Keyboard navigation:** All interactive elements remain accessible
+- **Screen reader testing:** Verify beta status is announced clearly
+
+### Maintenance Guidelines
+
+**When updating beta status:**
+1. Update BetaBanner component first (most visible)
+2. Update pricing tiers strikethrough/badges
+3. Update FAQ data to match messaging
+4. Update metadata (title, description) for SEO
+5. Test all viewports and both color modes
+
+**When transitioning out of beta:**
+1. Remove or hide BetaBanner component
+2. Remove "FREE During Beta" badges
+3. Remove strikethrough from pricing
+4. Update FAQ answers to remove beta references
+5. Update metadata to remove beta status
+6. Keep promotional callouts for early users (if applicable)
+
+---
+
 ## SEO Patterns (Marketing Site)
 
 For comprehensive SEO documentation including metadata patterns, schema.org structured data, sitemap configuration, image optimization, and testing procedures, see **[seo.md](./seo.md)**.
 
 ---
 
-**Last Updated:** 2025-10-24 (PostHog analytics integration patterns)
+**Last Updated:** 2025-10-27 (Beta messaging patterns, PostHog analytics integration patterns)
 **Next.js:** 16.0.0
 **React:** 19.2.0

--- a/apps/marketing/app/pricing/page.tsx
+++ b/apps/marketing/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
+import { BetaBanner } from '@/components/pricing/beta-banner';
 import { PricingHeader } from '@/components/pricing/pricing-header';
 import { PricingTiers } from '@/components/pricing/pricing-tiers';
 import { ComparisonTable } from '@/components/pricing/comparison-table';
@@ -10,12 +11,11 @@ import { PricingCta } from '@/components/pricing/pricing-cta';
 import { OfferSchema } from '@/components/structured-data/offer-schema';
 
 export const metadata: Metadata = {
-  title:
-    'BragDoc Pricing: Free Achievement Tracking, Optional Cloud AI - $4.99/mo',
+  title: 'BragDoc Pricing: Free Open Beta - One Year Free Offer',
   description:
-    'BragDoc is free to use with your own LLM. Optional cloud AI features are just $4.99/month. No contracts, cancel anytime. Compare free vs paid plans.',
+    'BragDoc is in open beta with all features FREE. Sign up now and get one year free when we launch at $4.99/month. No credit card required.',
   keywords:
-    'bragdoc pricing, free achievement tracker, developer tool pricing, brag document cost',
+    'bragdoc pricing, free achievement tracker, beta pricing, developer tool pricing, free open beta',
   alternates: {
     canonical: '/pricing',
   },
@@ -42,7 +42,10 @@ export default function PricingPage() {
     <div className="min-h-screen bg-background">
       <OfferSchema offers={pricingOffers} />
       <Header />
-      <main className="pt-16">
+      <div className="pt-16">
+        <BetaBanner />
+      </div>
+      <main>
         <PricingHeader />
         <PricingTiers />
         <PrivacyArchitecture />

--- a/apps/marketing/components/features-page-client.tsx
+++ b/apps/marketing/components/features-page-client.tsx
@@ -12,6 +12,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useImageLightbox } from '@/hooks/use-image-lightbox';
@@ -25,6 +26,7 @@ interface Feature {
   bullets: string[];
   screenshotAlt: string;
   screenshot?: string;
+  isBeta?: boolean;
 }
 
 const features: Feature[] = [
@@ -87,6 +89,7 @@ const features: Feature[] = [
     screenshotAlt:
       'BragDoc standup mode automatically generating daily meeting notes from recent Git commits',
     screenshot: '/screenshots/ui/standup.png',
+    isBeta: true,
   },
   {
     icon: FileText,
@@ -102,6 +105,7 @@ const features: Feature[] = [
     screenshotAlt:
       'AI-generated performance review document created from tracked achievements in BragDoc',
     screenshot: '/screenshots/ui/reports.png',
+    isBeta: true,
   },
   {
     icon: TrendingUp,
@@ -231,8 +235,13 @@ export function FeaturesPageClient() {
                         >
                           <Icon className="size-5 text-white" />
                         </div>
-                        <h2 className="text-2xl sm:text-3xl font-bold">
+                        <h2 className="text-2xl sm:text-3xl font-bold flex items-center gap-2 flex-wrap">
                           {feature.heading}
+                          {feature.isBeta && (
+                            <Badge variant="secondary" className="text-xs">
+                              Beta
+                            </Badge>
+                          )}
                         </h2>
                       </div>
                       <p className="text-muted-foreground mb-6 leading-relaxed">

--- a/apps/marketing/components/features-section.tsx
+++ b/apps/marketing/components/features-section.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import { Sparkles, FolderTree, FileText } from 'lucide-react';
 
 export function FeaturesSection() {
@@ -51,6 +52,7 @@ export function FeaturesSection() {
               'Export to PDF/Markdown',
               'Highlight key wins',
             ]}
+            isBeta={true}
           />
         </div>
       </div>
@@ -63,11 +65,13 @@ function FeatureCard({
   title,
   description,
   features,
+  isBeta,
 }: {
   icon: React.ReactNode;
   title: string;
   description: string;
   features: string[];
+  isBeta?: boolean;
 }) {
   return (
     <Card className="p-8 space-y-6 bg-card border-border hover:border-primary/50 transition-colors">
@@ -76,7 +80,14 @@ function FeatureCard({
       </div>
 
       <div className="space-y-3">
-        <h3 className="text-2xl font-bold">{title}</h3>
+        <h3 className="text-2xl font-bold flex items-center gap-2 flex-wrap">
+          {title}
+          {isBeta && (
+            <Badge variant="secondary" className="text-xs">
+              Beta
+            </Badge>
+          )}
+        </h3>
         <p className="text-muted-foreground leading-relaxed">{description}</p>
       </div>
 

--- a/apps/marketing/components/pricing/beta-banner.tsx
+++ b/apps/marketing/components/pricing/beta-banner.tsx
@@ -2,16 +2,18 @@ import { Sparkles } from 'lucide-react';
 
 export function BetaBanner() {
   return (
-    <div className="bg-gradient-to-r from-[oklch(0.65_0.25_262)] to-[oklch(0.7_0.25_280)] dark:from-[oklch(0.7_0.25_262)] dark:to-[oklch(0.75_0.25_280)] text-white py-4">
+    <div className="bg-gradient-to-r from-purple-600 to-purple-500 dark:from-purple-700 dark:to-purple-600 text-white py-4">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-center gap-3 text-center">
           <Sparkles className="size-5 shrink-0" />
           <div>
-            <p className="font-semibold text-sm sm:text-base">
-              Early Beta - All cloud AI features currently FREE
+            <p className="font-bold text-base sm:text-lg">
+              OPEN BETA - All Features Currently{' '}
+              <span className="text-green-300">FREE</span>
             </p>
-            <p className="text-xs sm:text-sm opacity-90">
-              Lock in early pricing when we launch
+            <p className="text-sm sm:text-base opacity-95">
+              Sign up now and get <strong>one year free</strong> when we launch
+              paid plans
             </p>
           </div>
         </div>

--- a/apps/marketing/components/pricing/comparison-table.tsx
+++ b/apps/marketing/components/pricing/comparison-table.tsx
@@ -211,14 +211,20 @@ export function ComparisonTable() {
                   Free
                 </TableCell>
                 <TableCell className="text-center font-semibold">
-                  $4.99/mo
-                  <span className="text-xs text-muted-foreground block font-normal">
-                    or $44.99/year
+                  <div className="text-green-600 dark:text-green-500 text-lg">
+                    FREE (Beta)
+                  </div>
+                  <span className="text-xs text-muted-foreground block line-through opacity-60">
+                    $4.99/mo or $44.99/year*
                   </span>
                 </TableCell>
               </TableRow>
             </TableBody>
           </Table>
+          <p className="text-sm text-muted-foreground mt-4 text-center">
+            * Future pricing after beta launch. All beta users get one year
+            free.
+          </p>
         </div>
       </div>
     </section>

--- a/apps/marketing/components/pricing/pricing-faq.tsx
+++ b/apps/marketing/components/pricing/pricing-faq.tsx
@@ -13,6 +13,24 @@ export function PricingFaq() {
           Pricing FAQ
         </h2>
         <Accordion type="single" collapsible className="max-w-3xl mx-auto">
+          <AccordionItem value="item-beta-1">
+            <AccordionTrigger>
+              Is BragDoc really free right now?
+            </AccordionTrigger>
+            <AccordionContent>
+              Yes! We're in open beta and all features are completely free.
+              Anyone who signs up during beta gets{' '}
+              <strong>one year free</strong> when we launch paid plans.
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="item-beta-2">
+            <AccordionTrigger>What happens when beta ends?</AccordionTrigger>
+            <AccordionContent>
+              When we exit beta, pricing will be $4.99/month or $44.99/year. If
+              you signed up during beta, you'll automatically get one year free
+              before any charges begin.
+            </AccordionContent>
+          </AccordionItem>
           <AccordionItem value="item-1">
             <AccordionTrigger>
               What's the difference between Free and Full Account?
@@ -20,9 +38,10 @@ export function PricingFaq() {
             <AccordionContent>
               The free account lets you manually track achievements and explore
               BragDoc, but it doesn't include any AI features. The Full Account
-              ($4.99/month) gives you AI-powered achievement extraction from git
-              commits, AI-generated standup summaries, performance review
-              documents, and all the features that make BragDoc truly powerful.
+              (future pricing $4.99/month after beta) gives you AI-powered
+              achievement extraction from git commits, AI-generated standup
+              summaries, performance review documents, and all the features that
+              make BragDoc truly powerful. During beta, all features are free.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-2">
@@ -52,11 +71,11 @@ export function PricingFaq() {
           <AccordionItem value="item-4">
             <AccordionTrigger>Is there a free trial?</AccordionTrigger>
             <AccordionContent>
-              The free account serves as your trial - you can explore BragDoc
-              and manually track achievements to see if it fits your workflow.
-              When you're ready for the AI features, upgrade to a Full Account.
-              We don't offer a time-limited trial because we want you to make an
-              informed decision without pressure.
+              Currently everything is FREE during open beta, so there's nothing
+              to commit to. Plus, beta users get one year free when we launch
+              paid features. After beta, the free account serves as your trial -
+              you can explore BragDoc and manually track achievements to see if
+              it fits your workflow.
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-5">
@@ -71,11 +90,12 @@ export function PricingFaq() {
           <AccordionItem value="item-6">
             <AccordionTrigger>How does billing work?</AccordionTrigger>
             <AccordionContent>
-              Billing is simple and you can cancel anytime. Choose monthly
-              billing at $4.99/month or annual billing at $44.99/year (save
-              25%). There are no hidden fees, no setup costs, and no long-term
-              commitments. You can cancel your subscription at any time and
-              continue using the free account.
+              During open beta, there's no billing - everything is free. After
+              beta launch, billing will be simple and you can cancel anytime.
+              Choose monthly billing at $4.99/month or annual billing at
+              $44.99/year (save 25%). There are no hidden fees, no setup costs,
+              and no long-term commitments. Beta users automatically get one
+              year free before any charges begin.
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/apps/marketing/components/pricing/pricing-header.tsx
+++ b/apps/marketing/components/pricing/pricing-header.tsx
@@ -6,8 +6,11 @@ export function PricingHeader() {
           BragDoc Pricing: Free & Cloud AI Plans
         </h1>
         <p className="text-lg sm:text-xl text-muted-foreground max-w-3xl mx-auto text-balance">
-          Get the full power of AI-driven achievement tracking for $4.99/month.
-          Try it free, or self-host the open source version.
+          <span className="font-semibold text-green-600 dark:text-green-500">
+            Currently in open beta - all features FREE.
+          </span>{' '}
+          Future pricing $4.99/month when we launch. Sign up now for one year
+          free!
         </p>
       </div>
     </section>

--- a/apps/marketing/components/pricing/pricing-tiers.tsx
+++ b/apps/marketing/components/pricing/pricing-tiers.tsx
@@ -35,7 +35,8 @@ export function PricingTiers() {
                 Full Account
               </CardTitle>
               <CardDescription className="text-base">
-                Everything you need to track and showcase your achievements
+                Everything you need to track and showcase your achievements -
+                currently FREE during open beta
               </CardDescription>
 
               <div className="mt-6 flex justify-center">
@@ -75,28 +76,40 @@ export function PricingTiers() {
               </div>
 
               <div className="mt-6">
+                {/* Large "FREE" badge */}
+                <div className="text-center mb-4">
+                  <Badge className="text-2xl px-6 py-2 bg-green-600 dark:bg-green-500 text-white">
+                    FREE During Beta
+                  </Badge>
+                </div>
+
+                {/* Strikethrough future pricing */}
                 {billingPeriod === 'monthly' ? (
                   <div className="text-center">
-                    <div className="flex items-baseline justify-center gap-1">
-                      <span className="text-5xl font-bold">$4.99</span>
-                      <span className="text-muted-foreground text-lg">
+                    <div className="flex items-baseline justify-center gap-2 text-muted-foreground">
+                      <span className="text-3xl font-semibold line-through opacity-60">
+                        $4.99
+                      </span>
+                      <span className="text-base line-through opacity-60">
                         /month
                       </span>
                     </div>
-                    <p className="text-sm text-muted-foreground mt-2">
-                      Billed monthly
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Future price after beta
                     </p>
                   </div>
                 ) : (
                   <div className="text-center">
-                    <div className="flex items-baseline justify-center gap-1">
-                      <span className="text-5xl font-bold">$44.99</span>
-                      <span className="text-muted-foreground text-lg">
+                    <div className="flex items-baseline justify-center gap-2 text-muted-foreground">
+                      <span className="text-3xl font-semibold line-through opacity-60">
+                        $44.99
+                      </span>
+                      <span className="text-base line-through opacity-60">
                         /year
                       </span>
                     </div>
-                    <p className="text-sm text-muted-foreground mt-2">
-                      Billed annually
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Future price after beta
                     </p>
                   </div>
                 )}
@@ -153,6 +166,13 @@ export function PricingTiers() {
               </div>
             </CardContent>
             <CardFooter className="flex flex-col gap-3 pt-6">
+              {/* One-year-free callout */}
+              <div className="w-full p-3 rounded-lg bg-green-50 dark:bg-green-950/30 border border-green-200 dark:border-green-800">
+                <p className="text-sm font-medium text-green-700 dark:text-green-400 text-center">
+                  🎁 Sign up during beta → Get one year FREE when we launch
+                </p>
+              </div>
+
               <Button
                 size="lg"
                 className="w-full text-lg h-12 bg-[oklch(0.65_0.25_262)] hover:bg-[oklch(0.6_0.25_262)] dark:bg-[oklch(0.7_0.25_262)] dark:hover:bg-[oklch(0.65_0.25_262)]"
@@ -181,7 +201,9 @@ export function PricingTiers() {
           <Card className="bg-muted/30">
             <CardHeader>
               <CardTitle className="text-2xl">Free Account</CardTitle>
-              <CardDescription>Try BragDoc without AI features</CardDescription>
+              <CardDescription>
+                Try BragDoc without AI features - always free, even after beta
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <p className="text-muted-foreground mb-4">

--- a/apps/marketing/lib/faq-data.ts
+++ b/apps/marketing/lib/faq-data.ts
@@ -35,7 +35,7 @@ export const faqData: FAQCategory[] = [
       {
         question: 'Can I try it before committing?',
         answer:
-          'Yes! Everything is free to start. Optional paid features (cloud AI document generation) are only $4.99/month and you can try them risk-free.',
+          "Currently everything is FREE during open beta, so there's nothing to commit to. Plus, beta users get one year free when we launch paid features.",
       },
     ],
   },
@@ -119,12 +119,12 @@ export const faqData: FAQCategory[] = [
       {
         question: "What's actually free?",
         answer:
-          'Everything except cloud AI features. If you use your own LLM (like Ollama locally), BragDoc is completely free.',
+          'Currently in open beta, ALL features are free, including cloud AI. After beta, the free tier will exclude cloud AI features (future pricing $4.99/month). Beta users get one year free.',
       },
       {
         question: 'What do I pay for?',
         answer:
-          'Optional cloud AI document generation is $4.99/month. If you use your own LLM, you pay nothing.',
+          'During open beta, everything is free. After launch, optional cloud AI document generation will be $4.99/month. If you sign up during beta, you get one year free.',
       },
       {
         question: 'How much does LLM usage cost?',
@@ -133,15 +133,18 @@ export const faqData: FAQCategory[] = [
       },
       {
         question: 'Can I switch between free and paid?',
-        answer: 'Yes, anytime. No contracts or commitments.',
+        answer:
+          'Yes, anytime after beta ends. No contracts or commitments. During beta, everything is free for everyone.',
       },
       {
         question: 'What payment methods do you accept?',
-        answer: 'Credit card via Stripe. Cancel anytime with no penalties.',
+        answer:
+          'After beta ends, credit card via Stripe. Cancel anytime with no penalties. Currently, everything is free during open beta.',
       },
       {
         question: 'Can I get a refund?',
-        answer: "Yes, within 30 days if you're not satisfied.",
+        answer:
+          "Yes, within 30 days if you're not satisfied after beta ends and paid plans launch. During beta, everything is free so refunds don't apply.",
       },
       {
         question: 'Is there enterprise pricing?',

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "NEXT_DIST_DIR=.next-dev next dev -p 3001",
     "start": "next start -p 3001",
     "lint": "eslint . && biome lint --write --unsafe app/ components/ lib/ hooks/",
     "lint:fix": "eslint --fix . && biome lint --write --unsafe app/ components/ lib/ hooks/",


### PR DESCRIPTION
Implemented beta banners, pricing updates, and feature badges across
  the BragDoc marketing site to clearly communicate:

  - Open beta status with all features FREE
  - One year free offer for beta users
  - Future pricing ($4.99/month) shown as strikethrough

  Changes:
  - Enhanced beta banner component with prominent messaging
  - Updated pricing page (header, tiers, comparison table, FAQ)
  - Added beta badges to Standup Mode and AI Document Generation
  - Updated 7 FAQ answers to clarify beta status
  - Updated SEO metadata for pricing page
  - Documented reusable beta messaging patterns