### PR TITLE
Transform demo achievement dates to spread evenly over 270 days

### DIFF
--- a/apps/web/lib/create-demo-account.ts
+++ b/apps/web/lib/create-demo-account.ts
@@ -125,7 +125,7 @@ export async function createDemoAccount(options?: {
         name: 'Demo User',
         level: 'demo',
         emailVerified: true, // Boolean, not Date (changed for Better Auth)
-        provider: 'credentials', // Better Auth uses 'credentials' for email/password
+        provider: 'credential', // Better Auth uses 'credential' for email/password
         preferences: {
           language: 'en',
         },
@@ -137,11 +137,11 @@ export async function createDemoAccount(options?: {
     }
 
     // Create credential account for Better Auth email/password authentication
-    // Better Auth requires an Account record with provider='credentials'
+    // Better Auth requires an Account record with provider='credential'
     await db.insert(account).values({
       userId: demoUser.id,
-      accountId: demoUser.email, // Use email as accountId for credentials provider
-      providerId: 'credentials', // Provider is 'credentials' for email/password
+      accountId: demoUser.email, // Use email as accountId for credential provider
+      providerId: 'credential', // Provider is 'credential' for email/password
       password: hashedPassword,
     });
 

--- a/apps/web/lib/demo-data-import.ts
+++ b/apps/web/lib/demo-data-import.ts
@@ -7,8 +7,60 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { exportDataSchema } from '@/lib/export-import-schema';
+import {
+  exportDataSchema,
+  type ExportAchievement,
+} from '@/lib/export-import-schema';
 import { importUserData, type ImportStats } from '@/lib/import-user-data';
+
+/**
+ * Transforms achievement dates to spread evenly across the last 270 days (9 months)
+ *
+ * This keeps demo data fresh by distributing achievements evenly from 270 days ago
+ * to the present, regardless of their original dates. All date-related fields are
+ * transformed while preserving all other properties.
+ *
+ * @param achievements - Array of achievements from demo data with original dates
+ * @returns Array of achievements with transformed dates spanning 270 days
+ */
+function transformAchievementDates(
+  achievements: ExportAchievement[],
+): ExportAchievement[] {
+  // Sort achievements by original createdAt date (ascending - earliest first)
+  const sorted = [...achievements].sort((a, b) => {
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+
+  // Calculate date range: 270 days from present back to 270 days ago
+  const now = new Date();
+  const startDate = new Date(now.getTime() - 270 * 24 * 60 * 60 * 1000); // 270 days ago
+  const totalDays = 270;
+
+  // Calculate even spacing between achievements
+  // For 292 achievements over 270 days: spacing ≈ 0.924 days per achievement
+  const spacing = totalDays / sorted.length; // Days between each achievement
+  const spacingMs = spacing * 24 * 60 * 60 * 1000; // Convert to milliseconds
+
+  // Transform each achievement's dates
+  return sorted.map((achievement, index) => {
+    // Calculate new date for this achievement
+    // Achievement 0: 270 days ago (startDate)
+    // Achievement N: progressively closer to present
+    // Achievement last: very recent (≈0 days ago)
+    const newDate = new Date(startDate.getTime() + index * spacingMs);
+    const newDateString = newDate.toISOString();
+
+    // Transform all date fields to the new calculated date
+    return {
+      ...achievement,
+      createdAt: newDateString,
+      eventStart: achievement.eventStart ? newDateString : null,
+      eventEnd: achievement.eventEnd ? newDateString : null,
+      updatedAt: newDateString,
+      impactUpdatedAt: achievement.impactUpdatedAt ? newDateString : null,
+    };
+  });
+}
 
 /**
  * Imports demo data from the bundled demo-data.json file into a demo user account
@@ -39,6 +91,12 @@ export async function importDemoData(userId: string): Promise<ImportStats> {
       `Invalid demo data format: ${JSON.stringify(result.error.errors)}`,
     );
   }
+
+  // Transform achievement dates to spread evenly over 270 days
+  // This keeps demo data fresh without manual updates
+  result.data.achievements = transformAchievementDates(
+    result.data.achievements,
+  );
 
   // Use shared import function with new ID generation
   // Generate new IDs to avoid collisions with previous demo accounts


### PR DESCRIPTION
Demo mode now applies date transformation to achievements during import, spreading them evenly across the last 270 days (approximately 9 months) instead of using the original dates from the source data. This keeps the demo experience fresh without requiring manual updates to the demo data file.

The transformation is implemented in `demo-data-import.ts` as a preprocessing step before calling the shared `importUserData()` function. Achievements are sorted by their original `createdAt` date, then dates are recalculated with even spacing across the 270-day window. All date fields (`createdAt`, `eventStart`, `eventEnd`, `updatedAt`, `impactUpdatedAt`) are synchronized to the new calculated dates while all other properties (title, summary, details, impact, foreign keys) remain unchanged.

This change only affects demo mode imports. Regular user data imports continue to preserve original dates exactly as before.