### PR TITLE
feat: add zero state component to project details page

### DIFF
--- a/.claude/agents/documentation-manager.md
+++ b/.claude/agents/documentation-manager.md
@@ -175,12 +175,20 @@ Ensure documentation references are accurate and complete:
 
 **Technical Documentation Standards:**
 
-- **Concrete**: Provide actual code examples, not abstract descriptions
-- **Pattern-focused**: Document conventions and patterns, not every detail
+- **Concise**: 1-3 paragraphs per pattern/topic; focus on principles over implementation
+- **Pattern-focused**: Document design approaches and when to use them, not every detail
+- **Reference-based**: Point to example files by path rather than copying code
 - **Authoritative**: This is the source of truth for "how we do things"
-- **Comprehensive**: Cover all major aspects of each topic
+- **Comprehensive**: Cover all major aspects without excessive detail
 - **Up-to-date**: Must reflect current codebase state
 - **Cross-referenced**: Link to related documentation
+
+**Code Examples Policy:**
+- **Avoid code blocks** unless absolutely critical to understanding the concept
+- **Reference files instead**: "See `ProjectDetailsZeroState` (apps/web/components/project-details/project-zero-state.tsx)"
+- **Focus on concepts**: Explain when/why/what, not step-by-step implementation
+- **Maximum 10-15 lines** if a code example is truly necessary
+- The actual code is in the repository - documentation explains patterns and principles
 - **LLM-optimized**: Structured for easy consumption by AI agents
 
 **What to Document in Tech Docs:**
@@ -537,7 +545,7 @@ Before finalizing any documentation update, verify:
 ### Accuracy
 
 - [ ] Information matches current codebase state
-- [ ] Code examples are syntactically correct and follow project conventions
+- [ ] Code examples (if used) are minimal, syntactically correct, and follow conventions
 - [ ] File paths and references are correct
 - [ ] Technical details are precise and complete
 
@@ -560,7 +568,7 @@ Before finalizing any documentation update, verify:
 - [ ] Terminology aligns with other documentation
 - [ ] Formatting follows established patterns
 - [ ] Cross-references are bidirectional where appropriate
-- [ ] Code examples follow project style guide
+- [ ] Code examples (if any) are minimal and follow project style guide
 
 ### Maintainability
 
@@ -578,7 +586,7 @@ Before completing any task:
 - [ ] **Consistency check**: Verified changes align with related documentation
 - [ ] **Accuracy verification**: Spot-checked against actual codebase patterns
 - [ ] **Cross-references validated**: All file paths and references are correct
-- [ ] **Examples tested**: Code examples are valid and follow conventions
+- [ ] **Conciseness verified**: Documentation is 1-3 paragraphs, avoids code blocks
 - [ ] **Audience-appropriate**: Content matches technical vs. user audience needs
 - [ ] **Quality standards met**: Accuracy, completeness, clarity, consistency achieved
 - [ ] **Related updates considered**: Identified any follow-up documentation needs
@@ -739,9 +747,9 @@ Before completing any task:
 
 1. Review the implementation (LOG.md, changed files, PLAN.md)
 2. Read all relevant existing documentation thoroughly
-3. Update the appropriate documentation files
+3. Update the appropriate documentation files concisely (1-3 paragraphs per pattern)
 4. Ensure consistency across all related docs
-5. Add code examples from the actual implementation
+5. Reference implementation files by path rather than copying code
 6. Verify accuracy against the implemented code
 7. Report what was changed and why
 

--- a/.claude/docs/processes/plan-rules.md
+++ b/.claude/docs/processes/plan-rules.md
@@ -32,6 +32,21 @@ The .claude/docs/tech/ directory contains all the technical documentation meant 
 - **frontend-patterns.md** - Update for new component patterns or UI conventions
 - **deployment.md** - Update for deployment process or environment variable changes
 
+**Documentation Style Guidelines:**
+
+Technical documentation updates should be **concise and principle-focused**:
+- **NO code examples** unless absolutely critical to understanding the pattern
+- Focus on **design principles, architectural approaches, and reusable capabilities**
+- Typically **1-3 paragraphs maximum** per pattern/topic
+- Reference example files by path rather than including code blocks
+- Emphasize **when to use** a pattern and **key concepts**, not implementation details
+
+Example of good concise documentation:
+> "Detail pages can display zero states when associated collections are empty. Unlike dashboard zero states, detail page zero states preserve the entity header and swap out only the content area. Use conditional rendering, place components in feature-specific subdirectories (`components/[feature]/[feature]-zero-state.tsx`), and maintain consistent styling. **Examples:** ProjectDetailsZeroState, DashboardZeroState."
+
+Example of overly verbose documentation to **avoid**:
+> Including 100+ lines of TypeScript code examples, full component implementations, or step-by-step tutorials. The actual code is in the repository - documentation should focus on concepts and patterns.
+
 ### Feature Documentation (docs/)
 
 This should include a potential update to docs/FEATURES.md (if warranted) and updates to any other documents found in the docs/ directory. If we're adding a significant new piece of UI then we should have some document in that directory that describes the capabilities of that UI. There is a high chance this does not exist, so you should create it if not.

--- a/.claude/docs/tech/frontend-patterns.md
+++ b/.claude/docs/tech/frontend-patterns.md
@@ -1077,6 +1077,14 @@ export default async function Page() {
 
 **Real-world example**: See `apps/web/app/cli-auth/page.tsx` for the canonical implementation of this pattern.
 
+### Zero State Pattern in Detail Pages
+
+Detail pages can display zero states when associated collections are empty (e.g., a project with no achievements). Unlike dashboard zero states, detail page zero states preserve the entity header (name, description) and swap out only the content area. Use conditional rendering: check if collection is empty, then show zero state OR full content.
+
+Place zero state components in feature-specific subdirectories following the pattern `components/[feature]/[feature]-zero-state.tsx`. Components should use the same refresh pattern as dashboard zero states (router.refresh() with setTimeout for feedback) and maintain consistent styling (centered flex layout, max-w-2xl, shadcn/ui Card and Button components).
+
+**Examples:** `ProjectDetailsZeroState` (apps/web/components/project-details/project-zero-state.tsx), `DashboardZeroState` (apps/web/components/dashboard/dashboard-zero-state.tsx)
+
 ### Other Zero State Examples
 
 **Standup Zero State**: `apps/web/components/standups/standup-zero-state.tsx`

--- a/apps/web/components/project-details-content.tsx
+++ b/apps/web/components/project-details-content.tsx
@@ -14,6 +14,7 @@ import { ProjectDialog } from '@/components/project-dialog';
 import { WeeklyImpactChart } from '@/components/weekly-impact-chart';
 import { AchievementsTable } from '@/components/achievements-table';
 import { GenerateDocumentDialog } from '@/components/generate-document-dialog';
+import { ProjectDetailsZeroState } from '@/components/project-details/project-zero-state';
 import { Stat } from '@/components/shared/stat';
 import { useAchievements } from '@/hooks/use-achievements';
 import { useCompanies } from '@/hooks/use-companies';
@@ -201,94 +202,102 @@ export function ProjectDetailsContent({
           </div>
         </div>
 
-        {/* Project Stats */}
-        <div className="grid grid-cols-2 gap-2 lg:gap-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
-          <Stat
-            label="Project Achievements"
-            value={projectStats.totalAchievements}
-            badge={{
-              icon: <IconTarget className="size-3" />,
-              label: 'Total',
-            }}
-            footerHeading={{
-              text: 'Project contributions',
-              icon: <IconTarget className="size-4" />,
-            }}
-            footerDescription="All achievements for this project"
-          />
+        {/* Conditional: Zero state OR full content */}
+        {projectAchievements.length === 0 ? (
+          <ProjectDetailsZeroState projectName={project.name} />
+        ) : (
+          <>
+            {/* Project Stats */}
+            <div className="grid grid-cols-2 gap-2 lg:gap-6 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+              <Stat
+                label="Project Achievements"
+                value={projectStats.totalAchievements}
+                badge={{
+                  icon: <IconTarget className="size-3" />,
+                  label: 'Total',
+                }}
+                footerHeading={{
+                  text: 'Project contributions',
+                  icon: <IconTarget className="size-4" />,
+                }}
+                footerDescription="All achievements for this project"
+              />
 
-          <Stat
-            label="Total Impact Points"
-            value={projectStats.totalImpactPoints}
-            badge={{
-              icon: <IconTrendingUp className="size-3" />,
-              label: 'Project Total',
-            }}
-            footerHeading={{
-              text: 'Project impact score',
-              icon: <IconTrendingUp className="size-4" />,
-            }}
-            footerDescription={`Average ${projectStats.avgImpactPerAchievement} points per achievement`}
-          />
+              <Stat
+                label="Total Impact Points"
+                value={projectStats.totalImpactPoints}
+                badge={{
+                  icon: <IconTrendingUp className="size-3" />,
+                  label: 'Project Total',
+                }}
+                footerHeading={{
+                  text: 'Project impact score',
+                  icon: <IconTrendingUp className="size-4" />,
+                }}
+                footerDescription={`Average ${projectStats.avgImpactPerAchievement} points per achievement`}
+              />
 
-          <Stat
-            label="This Week's Impact"
-            value={projectStats.thisWeekImpact}
-            badge={{
-              icon: <IconTrendingUp className="size-3" />,
-              label: 'Week',
-            }}
-            footerHeading={{
-              text: 'Recent project activity',
-              icon: <IconTrendingUp className="size-4" />,
-            }}
-            footerDescription="Last 7 days"
-          />
+              <Stat
+                label="This Week's Impact"
+                value={projectStats.thisWeekImpact}
+                badge={{
+                  icon: <IconTrendingUp className="size-3" />,
+                  label: 'Week',
+                }}
+                footerHeading={{
+                  text: 'Recent project activity',
+                  icon: <IconTrendingUp className="size-4" />,
+                }}
+                footerDescription="Last 7 days"
+              />
 
-          <Stat
-            label="Project Duration"
-            value={
-              project.endDate
-                ? Math.ceil(
-                    (project.endDate.getTime() - project.startDate.getTime()) /
-                      (1000 * 60 * 60 * 24 * 30),
-                  )
-                : Math.ceil(
-                    (Date.now() - project.startDate.getTime()) /
-                      (1000 * 60 * 60 * 24 * 30),
-                  )
-            }
-            badge={{
-              icon: <IconCalendar className="size-3" />,
-              label: 'Months',
-            }}
-            footerHeading={{
-              text:
-                project.status === 'active'
-                  ? 'Ongoing project'
-                  : 'Completed project',
-              icon: <IconCalendar className="size-4" />,
-            }}
-            footerDescription={
-              project.status === 'active'
-                ? 'Since start date'
-                : 'Total duration'
-            }
-          />
-        </div>
+              <Stat
+                label="Project Duration"
+                value={
+                  project.endDate
+                    ? Math.ceil(
+                        (project.endDate.getTime() -
+                          project.startDate.getTime()) /
+                          (1000 * 60 * 60 * 24 * 30),
+                      )
+                    : Math.ceil(
+                        (Date.now() - project.startDate.getTime()) /
+                          (1000 * 60 * 60 * 24 * 30),
+                      )
+                }
+                badge={{
+                  icon: <IconCalendar className="size-3" />,
+                  label: 'Months',
+                }}
+                footerHeading={{
+                  text:
+                    project.status === 'active'
+                      ? 'Ongoing project'
+                      : 'Completed project',
+                  icon: <IconCalendar className="size-4" />,
+                }}
+                footerDescription={
+                  project.status === 'active'
+                    ? 'Since start date'
+                    : 'Total duration'
+                }
+              />
+            </div>
 
-        <WeeklyImpactChart achievements={projectAchievements} />
+            <WeeklyImpactChart achievements={projectAchievements} />
 
-        <AchievementsTable
-          achievements={projectAchievements}
-          projects={allProjects}
-          companies={allCompanies}
-          onImpactChange={handleImpactChange}
-          onSelectionChange={setSelectedAchievements}
-          selectedAchievements={selectedAchievements}
-          onGenerateDocument={handleGenerateDocument}
-          projectId={project.id}
-        />
+            <AchievementsTable
+              achievements={projectAchievements}
+              projects={allProjects}
+              companies={allCompanies}
+              onImpactChange={handleImpactChange}
+              onSelectionChange={setSelectedAchievements}
+              selectedAchievements={selectedAchievements}
+              onGenerateDocument={handleGenerateDocument}
+              projectId={project.id}
+            />
+          </>
+        )}
       </div>
 
       <ProjectDialog

--- a/apps/web/components/project-details/project-zero-state.tsx
+++ b/apps/web/components/project-details/project-zero-state.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+
+interface ProjectDetailsZeroStateProps {
+  projectName: string;
+}
+
+export function ProjectDetailsZeroState({
+  projectName,
+}: ProjectDetailsZeroStateProps) {
+  const [isChecking, setIsChecking] = useState(false);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const router = useRouter();
+
+  const handleCheckForAchievements = async () => {
+    setIsChecking(true);
+    setShowFeedback(false);
+
+    // Refresh the page to re-fetch data from the server
+    router.refresh();
+
+    // Show feedback after a brief delay if still on zero state
+    // Note: If achievements were added, the component will unmount during
+    // the refresh, so this timeout won't fire. The timeout only completes
+    // if we're still in the zero state (no achievements found).
+    setTimeout(() => {
+      setShowFeedback(true);
+      setIsChecking(false);
+    }, 1000);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center p-8">
+      <div className="max-w-2xl w-full space-y-6">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold">
+            No achievements yet for {projectName}
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Extract achievements from your Git commits using the CLI tool
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Extracting Achievements</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              <div>
+                <h3 className="font-semibold mb-1">1. Install the CLI</h3>
+                <code className="block bg-muted px-3 py-2 rounded-md text-sm">
+                  npm install -g @bragdoc/cli
+                </code>
+              </div>
+              <div>
+                <h3 className="font-semibold mb-1">2. Login (if needed)</h3>
+                <code className="block bg-muted px-3 py-2 rounded-md text-sm">
+                  bragdoc login
+                </code>
+              </div>
+              <div>
+                <h3 className="font-semibold mb-1">
+                  3. Initialize (if needed)
+                </h3>
+                <code className="block bg-muted px-3 py-2 rounded-md text-sm">
+                  bragdoc init
+                </code>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Run this in your Git repository for {projectName}
+                </p>
+              </div>
+              <div>
+                <h3 className="font-semibold mb-1">4. Extract achievements</h3>
+                <code className="block bg-muted px-3 py-2 rounded-md text-sm">
+                  bragdoc extract
+                </code>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col items-center gap-2">
+          <Button
+            size="lg"
+            onClick={handleCheckForAchievements}
+            disabled={isChecking}
+          >
+            {isChecking ? 'Checking...' : 'Check for achievements'}
+          </Button>
+
+          {showFeedback && (
+            <p className="text-sm text-muted-foreground text-center">
+              No achievements found for {projectName}. Did you run{' '}
+              <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                bragdoc extract
+              </code>{' '}
+              in this project&apos;s Git repository?
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/test/integration/TEST-PLAN.md
+++ b/test/integration/TEST-PLAN.md
@@ -578,6 +578,101 @@ As new features are added, expand this test plan to include:
 
 ---
 
+### 10. Project Details - Zero State for Empty Projects
+
+#### 10.1 Zero State Display
+- [ ] **Zero state appears** when project has no achievements
+- [ ] **Project header remains visible** (name, description, company, dates)
+- [ ] **Zero state headline** references the project name (e.g., "No achievements yet for [ProjectName]")
+- [ ] **CLI instructions card** is visible with "Extracting Achievements" heading
+- [ ] **All 4 CLI instruction steps** are present:
+  - [ ] Step 1: Install the CLI (`npm install -g @bragdoc/cli`)
+  - [ ] Step 2: Login (`bragdoc login`)
+  - [ ] Step 3: Initialize project (`bragdoc init`)
+  - [ ] Step 4: Extract achievements (`bragdoc extract`)
+- [ ] **Check button** is visible and enabled with text "Check for achievements"
+- [ ] **Stats grid** is NOT visible in zero state
+- [ ] **Weekly Impact Chart** is NOT visible in zero state
+- [ ] **Achievements Table** is NOT visible in zero state
+
+#### 10.2 Button Interactions
+- [ ] **Button click shows loading state**:
+  - Button text changes to "Checking..."
+  - Button is disabled during refresh
+- [ ] **Feedback message appears** when still no achievements:
+  - Message displays after ~1 second
+  - Message says "No achievements found for [ProjectName]. Did you run `bragdoc extract` in this project's Git repository?"
+  - Feedback message includes backtick-styled `bragdoc extract` command
+- [ ] **Zero state remains visible** when no achievements found after refresh
+
+#### 10.3 Project Transition
+- [ ] **Transitions to normal project view** when achievements are added:
+  - Zero state disappears after achievements are added via CLI
+  - Stats grid shows correct metrics
+  - Weekly Impact chart appears
+  - Achievements table displays with achievement rows
+  - No console errors during transition
+
+#### 10.4 Responsive Layout - Project Zero State
+- [ ] **Mobile viewport** (375px width):
+  - Zero state container is centered
+  - CLI instructions card fits viewport
+  - Code blocks don't overflow
+  - Button is appropriately sized and clickable
+  - Padding is appropriate for small screens
+- [ ] **Tablet viewport** (768px width):
+  - Zero state container is centered
+  - Layout uses max-width constraint
+  - Content is well-spaced and readable
+  - Button is centered below instructions
+- [ ] **Desktop viewport** (1920px width):
+  - Zero state has max-width constraint (~672px for max-w-2xl)
+  - Content is horizontally centered on large screens
+  - Project header and zero state properly positioned
+  - Overall layout is visually balanced
+
+#### 10.5 Zero State Accessibility
+- [ ] **Keyboard navigation works**:
+  - Button is reachable via Tab key
+  - Button has visible focus indicator
+  - Enter key triggers button click
+  - Space key triggers button click
+  - Tab order is logical
+- [ ] **No console errors** during zero state usage:
+  - No JavaScript errors in console
+  - No page errors (uncaught exceptions)
+  - No React warnings (hydration mismatches)
+  - No network errors (failed requests)
+
+#### 10.6 Comparison with Projects Having Achievements
+- [ ] **Projects WITH achievements show normal layout** (no zero state):
+  - Zero state is NOT displayed
+  - Project header is visible
+  - Stats grid displays with correct metrics
+  - Weekly Impact Chart displays data
+  - Achievements Table displays achievement rows
+  - All interactive elements (edit, generate document) work
+
+#### 10.7 Visual Consistency
+- [ ] **Styling matches DashboardZeroState pattern**:
+  - Same centered flex layout
+  - Same card styling and spacing
+  - Same button styling and hover states
+  - Same text colors and typography
+  - Same code block styling
+  - Feedback message styling matches pattern
+
+#### 10.8 Dialog Interactions (Edit Project, Generate Document)
+- [ ] **Edit Project dialog still works** while in zero state:
+  - Dialog opens and displays correctly
+  - Project information can be edited
+  - Changes are saved
+- [ ] **Generate Document dialog still works** while in zero state (if available):
+  - Cannot generate documents without achievements (expected behavior)
+  - Dialog shows appropriate messaging
+
+---
+
 ## Playwright Automated Test Scenarios
 
 Detailed Playwright test scenarios with TypeScript code examples are available in feature-specific test plans:
@@ -602,3 +697,26 @@ Each test includes:
 - Prerequisites and setup requirements
 
 **Implementation Note**: These tests should be integrated into `__tests__/e2e/dashboard-zero-state.spec.ts` with appropriate helper functions for login, auth token retrieval, and accessibility testing.
+
+### Project Details Zero State Tests
+
+See `tasks/214-add-zero-state-to-project-details-page/TEST_PLAN.md` for 10 detailed manual testing scenarios covering:
+
+1. **Zero State Display** - Verify zero state appears when project has no achievements
+2. **Zero State Content Verification** - Verify messaging and instructions are project-specific
+3. **Check for Achievements Button** - Test button loading state, refresh, and feedback message
+4. **Zero State Transitions to Content** - Verify transition when achievements are added
+5. **Comparison with Non-Empty Project** - Confirm normal layout for projects with achievements
+6. **Visual Consistency and Styling** - Verify matching DashboardZeroState pattern
+7. **TypeScript and Build Verification** - Ensure compilation without errors
+8. **Page Refresh and Data Re-fetching** - Verify router.refresh() functionality
+9. **Mobile Responsiveness** - Test on mobile, tablet, and desktop viewports
+10. **Accessibility and Keyboard Navigation** - Verify keyboard access and screen reader support
+
+Each test includes:
+- Detailed step-by-step procedures
+- Specific expected results
+- Failure criteria for clear pass/fail determination
+- Acceptance criteria checklist
+
+**Implementation Note**: These tests should be manually verified during QA phase. The component integrates with the existing ProjectDetailsContent page at `/projects/[id]`.


### PR DESCRIPTION
closes #214 
  Add a new `ProjectDetailsZeroState` component to display when a project has no achievements, guiding users to extract achievements using the `bragdoc extract` CLI command. The zero state follows the visual pattern of the existing
  `DashboardZeroState`, using centered flex layout with a Card-based design, and includes step-by-step instructions for users who are just getting started with achievement extraction.

  The component is integrated into `ProjectDetailsContent` with conditional rendering that displays the zero state instead of the stats grid, impact chart, and achievements table when `projectAchievements.length === 0`. The project header (name,
  description, company, dates) remains visible above the zero state for context. A "Check for achievements" button provides a refresh mechanism with loading and feedback states, allowing users to re-check for achievements after running the CLI.

  The implementation reuses the same state management and router refresh pattern as the dashboard zero state (useState for loading/feedback, router.refresh() with 1000ms timeout), ensuring consistent behavior across the application. No new
  dependencies are introduced, and all required UI components are already available in the component library.