### PR TITLE
Remove vestigial GitHub API integration code

### DIFF
--- a/.claude/docs/tech/authentication.md
+++ b/.claude/docs/tech/authentication.md
@@ -103,7 +103,6 @@ export const betterAuthConfig: Partial<BetterAuthOptions> = {
       provider: { type: 'string', required: false, defaultValue: 'credentials' },
       providerId: { type: 'string', required: false },
       preferences: { type: 'json', required: false },
-      githubAccessToken: { type: 'string', required: false },
       level: { type: 'string', required: true, defaultValue: 'free' },
       renewalPeriod: { type: 'string', required: false },
       lastPayment: { type: 'date', required: false },
@@ -293,6 +292,8 @@ google: {
 
 ### 3. GitHub OAuth
 
+GitHub OAuth is provided for **user authentication and sign-in only**. OAuth tokens are automatically stored by Better Auth in the `account` table for potential future use, but are not used for any API integration features.
+
 ```typescript
 github: {
   clientId: process.env.GITHUB_CLIENT_ID!,
@@ -317,9 +318,10 @@ github: {
 - `GITHUB_CLIENT_SECRET`
 
 **Features:**
-- User email access scope
-- Access token stored for GitHub API integration
+- User email access scope for sign-in
+- OAuth tokens stored by Better Auth in the `account` table
 - Fallback to login if name not provided
+- No API integration features (GitHub API integration feature was removed)
 
 ### 4. Demo Mode Authentication
 
@@ -388,7 +390,6 @@ export const user = pgTable('User', {
   // BragDoc-specific fields
   provider: varchar('provider', { length: 32 }).notNull().default('credentials'),
   providerId: varchar('provider_id', { length: 256 }),
-  githubAccessToken: varchar('github_access_token', { length: 256 }),
   preferences: jsonb('preferences').$type<UserPreferences>(),
   level: userLevelEnum('level').notNull().default('free'),
   renewalPeriod: renewalPeriodEnum('renewal_period').default('monthly'),
@@ -561,7 +562,6 @@ export async function getAuthUser(
         provider: decoded.provider as string,
         providerId: decoded.providerId as string,
         preferences: decoded.preferences as any,
-        githubAccessToken: decoded.githubAccessToken as string,
         level: decoded.level as any,
         renewalPeriod: decoded.renewalPeriod as any,
       } as User,
@@ -706,7 +706,6 @@ CLI JWT tokens contain:
 - `provider` - Auth provider (google, github, email)
 - `providerId` - Provider-specific user ID
 - `preferences` - User preferences (language, document instructions)
-- `githubAccessToken` - GitHub access token (if authenticated via GitHub)
 - `level` - Subscription level (free, basic, pro, demo)
 - `renewalPeriod` - Billing cycle (monthly, yearly)
 - `exp` - Expiration timestamp (30 days)

--- a/apps/web/app/api/cli/token/route.ts
+++ b/apps/web/app/api/cli/token/route.ts
@@ -34,7 +34,6 @@ export async function POST(request: Request) {
       provider: user.provider,
       providerId: user.providerId,
       preferences: user.preferences,
-      githubAccessToken: user.githubAccessToken,
       level: user.level,
       renewalPeriod: user.renewalPeriod,
     })

--- a/apps/web/lib/better-auth/config.ts
+++ b/apps/web/lib/better-auth/config.ts
@@ -97,12 +97,6 @@ export const betterAuthConfig: Partial<BetterAuthOptions> = {
         required: false,
       },
 
-      // GitHub access token (for GitHub integration)
-      githubAccessToken: {
-        type: 'string',
-        required: false,
-      },
-
       // Subscription level
       level: {
         type: 'string',

--- a/apps/web/lib/demo-data-cleanup.ts
+++ b/apps/web/lib/demo-data-cleanup.ts
@@ -16,8 +16,6 @@ import {
   chat,
   standup,
   standupDocument,
-  githubRepository,
-  githubPullRequest,
   emailPreferences,
   session,
 } from '@/database/schema';
@@ -33,8 +31,6 @@ import { eq } from 'drizzle-orm';
  *
  * Tables cleaned up:
  * - emailPreferences
- * - githubPullRequest (depends on githubRepository)
- * - githubRepository
  * - standupDocument (depends on standup)
  * - standup
  * - document
@@ -74,25 +70,6 @@ export async function cleanupDemoAccountData(userId: string): Promise<void> {
     await db
       .delete(emailPreferences)
       .where(eq(emailPreferences.userId, userId));
-
-    // GitHub pull requests (depend on repositories)
-    // Note: githubPullRequest references githubRepository, not user directly
-    // So we need to delete PR for this user's repositories
-    const userRepos = await db
-      .select({ id: githubRepository.id })
-      .from(githubRepository)
-      .where(eq(githubRepository.userId, userId));
-
-    for (const repo of userRepos) {
-      await db
-        .delete(githubPullRequest)
-        .where(eq(githubPullRequest.repositoryId, repo.id));
-    }
-
-    // GitHub repositories
-    await db
-      .delete(githubRepository)
-      .where(eq(githubRepository.userId, userId));
 
     // Standup documents (depend on standups)
     await db.delete(standupDocument).where(eq(standupDocument.userId, userId));

--- a/apps/web/lib/getAuthUser.ts
+++ b/apps/web/lib/getAuthUser.ts
@@ -80,7 +80,6 @@ export async function getAuthUser(
         provider: payload.provider as string,
         providerId: payload.providerId as string,
         preferences: payload.preferences as any,
-        githubAccessToken: payload.githubAccessToken as string,
         level: payload.level as any,
         renewalPeriod: payload.renewalPeriod as any,
       } as User,

--- a/packages/database/src/__tests__/models/user.test.ts
+++ b/packages/database/src/__tests__/models/user.test.ts
@@ -19,7 +19,6 @@ describe('User Model', () => {
     emailVerified: true, // Boolean (changed for Better Auth migration)
     lastPayment: null,
     providerId: null,
-    githubAccessToken: null,
     image: null,
     password: null,
     stripeCustomerId: null,

--- a/packages/database/src/migrations/0001_fancy_infant_terrible.sql
+++ b/packages/database/src/migrations/0001_fancy_infant_terrible.sql
@@ -1,0 +1,3 @@
+DROP TABLE "GitHubPullRequest" CASCADE;--> statement-breakpoint
+DROP TABLE "GitHubRepository" CASCADE;--> statement-breakpoint
+ALTER TABLE "User" DROP COLUMN "github_access_token";

--- a/packages/database/src/migrations/meta/0001_snapshot.json
+++ b/packages/database/src/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1367 @@
+{
+  "id": "aca5d67c-5a73-455c-aa8f-349e0cc494d7",
+  "prevId": "4d443b88-187e-4da6-8121-2fb6263703d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Account": {
+      "name": "Account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Account_userId_User_id_fk": {
+          "name": "Account_userId_User_id_fk",
+          "tableFrom": "Account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Achievement": {
+      "name": "Achievement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standup_document_id": {
+          "name": "standup_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_message_id": {
+          "name": "user_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_start": {
+          "name": "event_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_end": {
+          "name": "event_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_duration": {
+          "name": "event_duration",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "impact": {
+          "name": "impact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "impact_source": {
+          "name": "impact_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "impact_updated_at": {
+          "name": "impact_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Achievement_user_id_User_id_fk": {
+          "name": "Achievement_user_id_User_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Achievement_company_id_Company_id_fk": {
+          "name": "Achievement_company_id_Company_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Achievement_project_id_Project_id_fk": {
+          "name": "Achievement_project_id_Project_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Achievement_standup_document_id_StandupDocument_id_fk": {
+          "name": "Achievement_standup_document_id_StandupDocument_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "StandupDocument",
+          "columnsFrom": ["standup_document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Achievement_user_message_id_UserMessage_id_fk": {
+          "name": "Achievement_user_message_id_UserMessage_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "UserMessage",
+          "columnsFrom": ["user_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Company": {
+      "name": "Company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Company_user_id_User_id_fk": {
+          "name": "Company_user_id_User_id_fk",
+          "tableFrom": "Company",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_company_id_Company_id_fk": {
+          "name": "Document_company_id_Company_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Document_chat_id_Chat_id_fk": {
+          "name": "Document_chat_id_Chat_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Chat",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_preferences": {
+      "name": "email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_types": {
+          "name": "email_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_preferences_user_id_User_id_fk": {
+          "name": "email_preferences_user_id_User_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_remote_url": {
+          "name": "repo_remote_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Project_user_id_User_id_fk": {
+          "name": "Project_user_id_User_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Project_company_id_Company_id_fk": {
+          "name": "Project_company_id_Company_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Session": {
+      "name": "Session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Session_userId_User_id_fk": {
+          "name": "Session_userId_User_id_fk",
+          "tableFrom": "Session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Session_token_unique": {
+          "name": "Session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Standup": {
+      "name": "Standup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "companyId": {
+          "name": "companyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_ids": {
+          "name": "project_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_mask": {
+          "name": "days_mask",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Standup_userId_User_id_fk": {
+          "name": "Standup_userId_User_id_fk",
+          "tableFrom": "Standup",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Standup_companyId_Company_id_fk": {
+          "name": "Standup_companyId_Company_id_fk",
+          "tableFrom": "Standup",
+          "tableTo": "Company",
+          "columnsFrom": ["companyId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StandupDocument": {
+      "name": "StandupDocument",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "standupId": {
+          "name": "standupId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wip": {
+          "name": "wip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achievements_summary": {
+          "name": "achievements_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wip_source": {
+          "name": "wip_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "achievements_summary_source": {
+          "name": "achievements_summary_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "StandupDocument_standupId_Standup_id_fk": {
+          "name": "StandupDocument_standupId_Standup_id_fk",
+          "tableFrom": "StandupDocument",
+          "tableTo": "Standup",
+          "columnsFrom": ["standupId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "StandupDocument_userId_User_id_fk": {
+          "name": "StandupDocument_userId_User_id_fk",
+          "tableFrom": "StandupDocument",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credentials'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"language\":\"en\",\"documentInstructions\":\"\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "level": {
+          "name": "level",
+          "type": "user_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "renewal_period": {
+          "name": "renewal_period",
+          "type": "renewal_period",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "last_payment": {
+          "name": "last_payment",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserMessage": {
+      "name": "UserMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserMessage_userId_User_id_fk": {
+          "name": "UserMessage_userId_User_id_fk",
+          "tableFrom": "UserMessage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.renewal_period": {
+      "name": "renewal_period",
+      "schema": "public",
+      "values": ["monthly", "yearly"]
+    },
+    "public.user_level": {
+      "name": "user_level",
+      "schema": "public",
+      "values": ["free", "basic", "pro", "demo"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["active", "banned", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1761782229316,
       "tag": "0000_initial_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1762259704528,
+      "tag": "0001_fancy_infant_terrible",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -11,7 +11,6 @@ import {
   foreignKey,
   boolean,
   integer,
-  uniqueIndex,
   pgEnum,
   time,
   date,
@@ -61,7 +60,6 @@ export const user = pgTable('User', {
     .notNull()
     .default('credentials'),
   providerId: varchar('provider_id', { length: 256 }),
-  githubAccessToken: varchar('github_access_token', { length: 256 }),
   preferences: jsonb('preferences').$type<UserPreferences>().notNull().default({
     language: 'en',
     documentInstructions: '',
@@ -311,49 +309,6 @@ export const standupDocument = pgTable('StandupDocument', {
 });
 
 export type StandupDocument = InferSelectModel<typeof standupDocument>;
-
-// GitHub Integration Tables
-export const githubRepository = pgTable('GitHubRepository', {
-  id: uuid('id').primaryKey().notNull().defaultRandom(),
-  userId: uuid('user_id')
-    .notNull()
-    .references(() => user.id),
-  name: varchar('name', { length: 256 }).notNull(),
-  fullName: varchar('full_name', { length: 512 }).notNull(),
-  description: text('description'),
-  private: boolean('private').notNull().default(false),
-  lastSynced: timestamp('last_synced'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-});
-
-export type GitHubRepository = InferSelectModel<typeof githubRepository>;
-
-export const githubPullRequest = pgTable(
-  'GitHubPullRequest',
-  {
-    id: uuid('id').primaryKey().notNull().defaultRandom(),
-    repositoryId: uuid('repository_id')
-      .notNull()
-      .references(() => githubRepository.id),
-    prNumber: integer('pr_number').notNull(),
-    title: varchar('title', { length: 512 }).notNull(),
-    description: text('description'),
-    state: varchar('state', { length: 32 }).notNull(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
-    mergedAt: timestamp('merged_at'),
-    achievementId: uuid('achievement_id').references(() => achievement.id),
-  },
-  (table) => ({
-    repoAndPrUnique: uniqueIndex('repo_pr_unique').on(
-      table.repositoryId,
-      table.prNumber,
-    ),
-  }),
-);
-
-export type GitHubPullRequest = InferSelectModel<typeof githubPullRequest>;
 
 // Better Auth Account table
 export const account = pgTable('Account', {


### PR DESCRIPTION
  Remove abandoned GitHub API integration code that was never completed and is no longer being used. This includes the `githubRepository` and `githubPullRequest` database table definitions (for analyzing repositories and pull requests) and the
  custom `githubAccessToken` user field (for making GitHub API calls). The removal simplifies the codebase by eliminating redundant token storage and cleaning up references in account deletion and CLI token generation logic.

  **Important:** GitHub OAuth for user sign-in remains fully functional. Users can continue to sign in with GitHub, Google, or Email/magic link. The removed code was for a separate feature that would have used the GitHub API to analyze
  repositories and extract achievements from pull requests—this feature was abandoned in favor of using local Git commands via our CLI tool.

  These changes are safe because the GitHub API integration database tables were never migrated to production, so no existing user data is affected. The custom `githubAccessToken` field was intended for GitHub API calls (not authentication), and
  Better Auth's `account` table already manages OAuth tokens automatically for sign-in purposes. The generic `project.repoRemoteUrl` field is preserved for future use with any Git repository.

  The following components are removed: `githubRepository` and `githubPullRequest` table definitions from schema, `githubAccessToken` custom field from user schema and Better Auth config, GitHub table references from account deletion and demo
  cleanup logic, and `githubAccessToken` from CLI JWT token generation. Technical documentation is updated to clarify that GitHub OAuth is for authentication only (no API integration).