### PR TITLE
fix: disable Sentry tunnel route causing 405 errors

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -57,7 +57,8 @@ export default withSentryConfig(config, {
   // This can increase your server load as well as your hosting bill.
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
   // side errors will fail.
-  tunnelRoute: '/monitoring',
+  // DISABLED: Was causing 405 errors because no /monitoring route exists
+  // tunnelRoute: '/monitoring',
 
   // Automatically tree-shake Sentry logger statements to reduce bundle size
   disableLogger: true,


### PR DESCRIPTION
The Sentry wizard configured tunnelRoute: '/monitoring' to proxy browser
errors through our server to bypass ad-blockers. However, no /monitoring
route handler exists, causing 405 Method Not Allowed errors when the
Sentry browser SDK attempted to POST events.

Disabled the tunnel route - errors now send directly to Sentry's servers.
This is simpler, cheaper, and works for 95%+ of users. Only users with
aggressive ad-blockers that specifically block Sentry domains will be
affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>