### PR TITLE
feat(workstreams): add configurable time period and project filtering…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ Shared TypeScript configurations: `base.json`, `nextjs.json`, `react-library.jso
 
 ### Overview
 
-Workstreams provide automatic semantic clustering of achievements across projects to identify work patterns and themes. The feature uses machine learning to group related achievements, helping users understand their professional development.
+Workstreams provide automatic semantic clustering of achievements across projects to identify work patterns and themes. The feature uses machine learning to group related achievements, helping users understand their professional development. Users can optionally filter by time period and/or projects when generating workstreams.
 
 ### Architecture
 
@@ -314,16 +314,17 @@ Workstreams provide automatic semantic clustering of achievements across project
 - **Database:** pgvector extension for 1536-dimensional embedding storage
 - **API:** RESTful endpoints for generation, CRUD, and manual assignment
 - **UI:** Dashboard widget, dedicated page, achievement integration
+- **Filtering:** Optional time range and project filters for focused clustering
 
 ### Key Components
 
 **Database Tables:**
 - `Achievement` - Extended with embedding vectors and workstream assignments
 - `Workstream` - Stores clusters with cached centroids
-- `WorkstreamMetadata` - Tracks clustering history
+- `WorkstreamMetadata` - Tracks clustering history and generation parameters
 
 **API Endpoints:**
-- `POST /api/workstreams/generate` - Trigger clustering
+- `POST /api/workstreams/generate` - Trigger clustering (supports optional filters)
 - `GET /api/workstreams` - List workstreams
 - `GET/PUT/DELETE /api/workstreams/[id]` - CRUD operations
 - `POST /api/workstreams/assign` - Manual assignment
@@ -333,6 +334,22 @@ Workstreams provide automatic semantic clustering of achievements across project
 - `WorkstreamCard` - Summary display
 - `WorkstreamStatus` - Dashboard widget
 - `useWorkstreams` - Data fetching hook
+
+### Filtering for Clustering
+
+Users can optionally specify filters when generating workstreams to focus clustering on specific time periods and/or projects:
+
+**Filter Parameters:**
+- `timeRange`: Optional start and end dates (ISO 8601 format, max 24 months)
+- `projectIds`: Optional array of project UUIDs to include
+
+**Behavior:**
+- All filter parameters are optional
+- When no filter provided, defaults to last 12 months (backward compatible)
+- Filters apply only to clustering operation (not embedding generation)
+- Embeddings are generated for all achievements (cost optimization)
+- Filter changes automatically trigger full re-clustering for accuracy
+- Achievements outside current filters are auto-assigned to nearest workstreams
 
 ### Implementation Details
 
@@ -348,9 +365,9 @@ Workstreams provide automatic semantic clustering of achievements across project
 - `buildWorkstreamBreakdown()` - Format workstream details for full clustering responses
 
 For detailed technical documentation, see:
-- Database schema: `.claude/docs/tech/database.md`
-- ML implementation: `.claude/docs/tech/ai-integration.md`
-- API patterns: `.claude/docs/tech/api-conventions.md` (includes detailed POST /api/workstreams/generate response structures)
+- Database schema: `.claude/docs/tech/database.md` (includes generationParams and filteredAchievementCount)
+- ML implementation: `.claude/docs/tech/ai-integration.md` (includes filtering strategy section)
+- API patterns: `.claude/docs/tech/api-conventions.md` (includes detailed POST /api/workstreams/generate request/response with filters)
 - UI components: `.claude/docs/tech/frontend-patterns.md`
 
 ---

--- a/apps/web/app/(app)/workstreams/page.tsx
+++ b/apps/web/app/(app)/workstreams/page.tsx
@@ -3,12 +3,19 @@ import { SidebarInset } from '@/components/ui/sidebar';
 import { WorkstreamsZeroState } from '@/components/workstreams/workstreams-zero-state';
 import { WorkstreamStats } from '@/components/workstreams/workstream-stats';
 import { WorkstreamDateFilter } from '@/components/workstreams/workstream-date-filter';
+import { WorkstreamsHeader } from '@/components/workstreams/workstreams-header';
 import { AppPage } from '@/components/shared/app-page';
 import { AppContent } from '@/components/shared/app-content';
 import { WorkstreamsClient } from '@/components/workstreams/workstreams-client';
 import { auth } from '@/lib/better-auth/server';
-import { db, workstream, achievement, project } from '@bragdoc/database';
-import { eq, and, gte, lte, count } from 'drizzle-orm';
+import {
+  db,
+  workstream,
+  achievement,
+  project,
+  getWorkstreamMetadata,
+} from '@bragdoc/database';
+import { eq, and, gte, lte, count, inArray } from 'drizzle-orm';
 import { subMonths, startOfDay, endOfDay } from 'date-fns';
 import { headers } from 'next/headers';
 import type { AchievementWithRelations } from '@/lib/types/achievement';
@@ -70,47 +77,72 @@ export default async function WorkstreamsPage({
   const datePreset = params.preset || '6m';
   const { startDate, endDate } = calculateDateRange(datePreset);
 
+  // Fetch workstreams and metadata in parallel first
+  const [userWorkstreams, metadata] = await Promise.all([
+    db.select().from(workstream).where(eq(workstream.userId, userId)),
+    getWorkstreamMetadata(userId),
+  ]);
+
+  // Get stored generation filters from metadata (if workstreams exist)
+  const generationParams = metadata?.generationParams;
+  const storedProjectIds = generationParams?.projectIds;
+  const storedTimeRange = generationParams?.timeRange;
+
   // Build WHERE conditions for achievements query
   const achievementConditions = [eq(achievement.userId, userId)];
 
-  // Add date filtering to SQL query instead of JavaScript
-  if (startDate) {
+  // Apply stored project filter from generation params (if any)
+  if (storedProjectIds && storedProjectIds.length > 0) {
+    achievementConditions.push(
+      inArray(achievement.projectId, storedProjectIds),
+    );
+  }
+
+  // Apply stored time range from generation params, falling back to UI preset
+  // Priority: stored time range > UI preset
+  if (storedTimeRange?.startDate) {
+    achievementConditions.push(
+      gte(achievement.eventStart, new Date(storedTimeRange.startDate)),
+    );
+  } else if (startDate) {
     achievementConditions.push(gte(achievement.eventStart, startDate));
   }
-  if (endDate) {
+
+  if (storedTimeRange?.endDate) {
+    achievementConditions.push(
+      lte(achievement.eventStart, new Date(storedTimeRange.endDate)),
+    );
+  } else if (endDate) {
     achievementConditions.push(lte(achievement.eventStart, endDate));
   }
 
-  // Fetch workstreams and filtered achievements with relations in parallel
-  const [userWorkstreams, achievementResults] = await Promise.all([
-    db.select().from(workstream).where(eq(workstream.userId, userId)),
-    db
-      .select({
-        // Achievement fields - exclude heavy/unused fields
-        id: achievement.id,
-        workstreamId: achievement.workstreamId,
-        title: achievement.title,
-        summary: achievement.summary,
-        eventStart: achievement.eventStart,
-        createdAt: achievement.createdAt,
-        impact: achievement.impact,
-        impactSource: achievement.impactSource,
-        // Excluded: userId, companyId, projectId, standupDocumentId, userMessageId,
-        // details, eventEnd, eventDuration, isArchived, source, impactUpdatedAt,
-        // updatedAt, workstreamSource, embedding (1536 dimensions!), embeddingModel,
-        // embeddingGeneratedAt
+  // Fetch filtered achievements with relations
+  const achievementResults = await db
+    .select({
+      // Achievement fields - exclude heavy/unused fields
+      id: achievement.id,
+      workstreamId: achievement.workstreamId,
+      title: achievement.title,
+      summary: achievement.summary,
+      eventStart: achievement.eventStart,
+      createdAt: achievement.createdAt,
+      impact: achievement.impact,
+      impactSource: achievement.impactSource,
+      // Excluded: userId, companyId, projectId, standupDocumentId, userMessageId,
+      // details, eventEnd, eventDuration, isArchived, source, impactUpdatedAt,
+      // updatedAt, workstreamSource, embedding (1536 dimensions!), embeddingModel,
+      // embeddingGeneratedAt
 
-        // Project fields - only what we need for display
-        project: {
-          id: project.id,
-          name: project.name,
-          color: project.color,
-        },
-      })
-      .from(achievement)
-      .leftJoin(project, eq(achievement.projectId, project.id))
-      .where(and(...achievementConditions)),
-  ]);
+      // Project fields - only what we need for display
+      project: {
+        id: project.id,
+        name: project.name,
+        color: project.color,
+      },
+    })
+    .from(achievement)
+    .leftJoin(project, eq(achievement.projectId, project.id))
+    .where(and(...achievementConditions));
 
   // Transform to AchievementWithRelations type
   // Note: We're setting company and userMessage to null since we don't fetch them
@@ -153,7 +185,44 @@ export default async function WorkstreamsPage({
       <SidebarInset>
         <SiteHeader title="Workstreams">
           {!showZeroState && (
-            <WorkstreamDateFilter initialPreset={datePreset} />
+            <WorkstreamsHeader
+              showFilters={!showZeroState}
+              storedProjectIds={storedProjectIds}
+              storedTimeRange={storedTimeRange}
+              filterDisplay={
+                <div className="flex items-center gap-4">
+                  {/* Show active filter info when stored generation params are applied */}
+                  {(storedProjectIds || storedTimeRange) && (
+                    <span className="text-sm text-muted-foreground">
+                      <span className="font-medium text-foreground">
+                        Filtered:{' '}
+                      </span>
+                      {storedTimeRange && (
+                        <span>
+                          {new Date(
+                            storedTimeRange.startDate,
+                          ).toLocaleDateString()}{' '}
+                          -{' '}
+                          {new Date(
+                            storedTimeRange.endDate,
+                          ).toLocaleDateString()}
+                        </span>
+                      )}
+                      {storedTimeRange && storedProjectIds && (
+                        <span className="mx-1">•</span>
+                      )}
+                      {storedProjectIds && (
+                        <span>
+                          {storedProjectIds.length} project
+                          {storedProjectIds.length === 1 ? '' : 's'}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  <WorkstreamDateFilter initialPreset={datePreset} />
+                </div>
+              }
+            />
           )}
         </SiteHeader>
         <AppContent>

--- a/apps/web/app/api/achievements/count/route.ts
+++ b/apps/web/app/api/achievements/count/route.ts
@@ -1,0 +1,64 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getAuthUser } from 'lib/getAuthUser';
+import { db, achievement } from '@bragdoc/database';
+import { eq, and, gte, lte, inArray, count } from 'drizzle-orm';
+
+/**
+ * GET /api/achievements/count
+ *
+ * Returns the count of achievements matching the filter criteria.
+ *
+ * Query parameters:
+ * - startDate: ISO 8601 date string (optional)
+ * - endDate: ISO 8601 date string (optional)
+ * - projectIds: comma-separated list of project UUIDs (optional)
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const auth = await getAuthUser(req);
+    if (!auth?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const url = new URL(req.url);
+    const searchParams = url.searchParams;
+    const startDate = searchParams.get('startDate');
+    const endDate = searchParams.get('endDate');
+    const projectIdsParam = searchParams.get('projectIds');
+
+    // Build WHERE conditions
+    const conditions = [eq(achievement.userId, auth.user.id)];
+
+    // Add date filters
+    if (startDate) {
+      conditions.push(gte(achievement.eventStart, new Date(startDate)));
+    }
+    if (endDate) {
+      conditions.push(lte(achievement.eventStart, new Date(endDate)));
+    }
+
+    // Add project filter (supports multiple project IDs)
+    if (projectIdsParam) {
+      const projectIds = projectIdsParam.split(',').filter(Boolean);
+      if (projectIds.length > 0) {
+        conditions.push(inArray(achievement.projectId, projectIds));
+      }
+    }
+
+    // Execute count query
+    const result = await db
+      .select({ count: count() })
+      .from(achievement)
+      .where(and(...conditions));
+
+    const totalCount = result[0]?.count ?? 0;
+
+    return NextResponse.json({ count: totalCount });
+  } catch (error) {
+    console.error('Error counting achievements:', error);
+    return NextResponse.json(
+      { error: 'Failed to count achievements' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/components/workstreams/workstream-config-dialog.tsx
+++ b/apps/web/components/workstreams/workstream-config-dialog.tsx
@@ -1,0 +1,369 @@
+'use client';
+
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Card, CardContent } from '@/components/ui/card';
+import { Loader2 } from 'lucide-react';
+import { useWorkstreamsActions } from '@/hooks/use-workstreams';
+import { useProjects } from '@/hooks/useProjects';
+import { useRouter } from 'next/navigation';
+
+interface WorkstreamConfigDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentFilters?: {
+    timeRange?: { startDate: string; endDate: string };
+    projectIds?: string[];
+  };
+}
+
+const timePresets = [
+  { value: '6m', label: 'Last 6 months' },
+  { value: '12m', label: 'Last 12 months' },
+  { value: '18m', label: 'Last 18 months' },
+  { value: '24m', label: 'Last 24 months' },
+];
+
+function getDateRangeFromPreset(preset: string): {
+  startDate: Date;
+  endDate: Date;
+} {
+  const endDate = new Date();
+  const startDate = new Date();
+
+  const months = Number.parseInt(preset.replace('m', ''), 10);
+  startDate.setMonth(startDate.getMonth() - months);
+
+  return { startDate, endDate };
+}
+
+/**
+ * Convert stored date range to a preset if possible
+ * If the dates don't match any preset, returns null
+ */
+function getPresetFromDateRange(
+  startDate?: string,
+  endDate?: string,
+): string | null {
+  if (!startDate || !endDate) return null;
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+  const today = new Date();
+
+  // Check if end date is approximately today
+  const daysDiff =
+    Math.abs(today.getTime() - end.getTime()) / (1000 * 60 * 60 * 24);
+  if (daysDiff > 1) return null;
+
+  // Check each preset
+  for (const preset of timePresets) {
+    const { startDate: presetStart } = getDateRangeFromPreset(preset.value);
+    const monthsDiff = Math.round(
+      (today.getTime() - start.getTime()) / (1000 * 60 * 60 * 24 * 30),
+    );
+    const presetMonths = Number.parseInt(preset.value.replace('m', ''), 10);
+    if (Math.abs(monthsDiff - presetMonths) <= 1) {
+      return preset.value;
+    }
+  }
+
+  return null;
+}
+
+export function WorkstreamConfigDialog({
+  open,
+  onOpenChange,
+  currentFilters,
+}: WorkstreamConfigDialogProps) {
+  const router = useRouter();
+  const [timePreset, setTimePreset] = useState('12m');
+  const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([]);
+  const [filteredCount, setFilteredCount] = useState<number | null>(null);
+  const [isLoadingCount, setIsLoadingCount] = useState(false);
+
+  const { projects, isLoading: projectsLoading } = useProjects();
+  const { generateWorkstreams, isGenerating, generationStatus } =
+    useWorkstreamsActions();
+
+  // Initialize form with current filters when dialog opens
+  useEffect(() => {
+    if (open && currentFilters) {
+      // Try to convert stored date range to preset
+      const preset = getPresetFromDateRange(
+        currentFilters.timeRange?.startDate,
+        currentFilters.timeRange?.endDate,
+      );
+      setTimePreset(preset || '12m');
+
+      // Pre-select projects
+      setSelectedProjectIds(currentFilters.projectIds || []);
+    } else if (open) {
+      // Reset to defaults if no current filters
+      setTimePreset('12m');
+      setSelectedProjectIds([]);
+    }
+  }, [open, currentFilters]);
+
+  // Fetch filtered achievement count when filters change
+  const fetchFilteredCount = useCallback(async () => {
+    setIsLoadingCount(true);
+    try {
+      const { startDate, endDate } = getDateRangeFromPreset(timePreset);
+      const params = new URLSearchParams({
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      });
+
+      // Only include projectIds if some (but not all) are selected
+      if (
+        selectedProjectIds.length > 0 &&
+        selectedProjectIds.length < projects.length
+      ) {
+        params.set('projectIds', selectedProjectIds.join(','));
+      }
+
+      const response = await fetch(
+        `/api/achievements/count?${params.toString()}`,
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setFilteredCount(data.count);
+      }
+    } catch (error) {
+      console.error('Failed to fetch filtered count:', error);
+    } finally {
+      setIsLoadingCount(false);
+    }
+  }, [timePreset, selectedProjectIds, projects.length]);
+
+  // Fetch count when filters change
+  useEffect(() => {
+    if (!open || projectsLoading) return;
+    fetchFilteredCount();
+  }, [
+    open,
+    timePreset,
+    selectedProjectIds,
+    projectsLoading,
+    fetchFilteredCount,
+  ]);
+
+  // Sort projects alphabetically
+  const sortedProjects = useMemo(() => {
+    return [...projects].sort((a, b) => a.name.localeCompare(b.name));
+  }, [projects]);
+
+  const handleProjectToggle = (projectId: string, checked: boolean) => {
+    if (checked) {
+      setSelectedProjectIds((prev) => [...prev, projectId]);
+    } else {
+      setSelectedProjectIds((prev) => prev.filter((id) => id !== projectId));
+    }
+  };
+
+  const handleSelectAll = () => {
+    if (selectedProjectIds.length === projects.length) {
+      setSelectedProjectIds([]);
+    } else {
+      setSelectedProjectIds(projects.map((p) => p.id));
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      // Build filters from form state
+      const { startDate, endDate } = getDateRangeFromPreset(timePreset);
+      const filters: {
+        timeRange?: { startDate: string; endDate: string };
+        projectIds?: string[];
+      } = {
+        timeRange: {
+          startDate: startDate.toISOString().split('T')[0] as string,
+          endDate: endDate.toISOString().split('T')[0] as string,
+        },
+      };
+
+      // Only include projectIds if some (but not all) are selected
+      if (
+        selectedProjectIds.length > 0 &&
+        selectedProjectIds.length < projects.length
+      ) {
+        filters.projectIds = selectedProjectIds;
+      }
+
+      await generateWorkstreams(filters);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Failed to regenerate workstreams:', error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Reconfigure Workstreams</DialogTitle>
+          <DialogDescription>
+            Change the time range and projects used for workstream generation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {/* Time Range Selection */}
+          <div className="space-y-2">
+            <Label htmlFor="config-time-range">Time Range</Label>
+            <Select value={timePreset} onValueChange={setTimePreset}>
+              <SelectTrigger id="config-time-range" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {timePresets.map((preset) => (
+                  <SelectItem key={preset.value} value={preset.value}>
+                    {preset.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Only achievements within this time range will be used for
+              clustering
+            </p>
+          </div>
+
+          {/* Project Selection */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Projects</Label>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleSelectAll}
+                className="h-auto py-1 px-2 text-xs"
+              >
+                {selectedProjectIds.length === projects.length
+                  ? 'Deselect all'
+                  : 'Select all'}
+              </Button>
+            </div>
+            {projectsLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading projects...
+              </div>
+            ) : projects.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No projects found</p>
+            ) : (
+              <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto border rounded-md p-3">
+                {sortedProjects.map((project) => (
+                  <div
+                    key={project.id}
+                    className="flex items-center gap-2 cursor-pointer hover:bg-muted/50 rounded px-1 py-0.5"
+                    onClick={() =>
+                      handleProjectToggle(
+                        project.id,
+                        !selectedProjectIds.includes(project.id),
+                      )
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleProjectToggle(
+                          project.id,
+                          !selectedProjectIds.includes(project.id),
+                        );
+                      }
+                    }}
+                    tabIndex={0}
+                    role="checkbox"
+                    aria-checked={selectedProjectIds.includes(project.id)}
+                  >
+                    <Checkbox
+                      checked={selectedProjectIds.includes(project.id)}
+                      onCheckedChange={(checked) =>
+                        handleProjectToggle(project.id, checked === true)
+                      }
+                      tabIndex={-1}
+                    />
+                    <span className="text-sm truncate" title={project.name}>
+                      {project.name}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {selectedProjectIds.length === 0 ||
+              selectedProjectIds.length === projects.length
+                ? 'All projects will be included'
+                : `${selectedProjectIds.length} project${selectedProjectIds.length === 1 ? '' : 's'} selected`}
+            </p>
+          </div>
+
+          {/* Achievement Count Display */}
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              {isLoadingCount ? (
+                <span className="inline-flex items-center gap-1">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Counting achievements...
+                </span>
+              ) : (
+                <>
+                  <span className="font-semibold">{filteredCount ?? 0}</span>{' '}
+                  achievements will be analyzed
+                </>
+              )}
+            </p>
+          </div>
+
+          {/* Warning Message */}
+          <Card className="bg-red-50 border-red-200 dark:bg-red-950 dark:border-red-800 lg:py-4">
+            <CardContent className="p-0 lg:px-4">
+              <p className="text-sm text-red-900 dark:text-red-100">
+                <span className="font-semibold">Warning:</span> This will
+                replace all existing workstreams and reassign your achievements.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isGenerating || isLoadingCount}
+          >
+            {isGenerating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {generationStatus || 'Regenerating...'}
+              </>
+            ) : (
+              'Regenerate Workstreams'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/workstreams/workstreams-header.tsx
+++ b/apps/web/components/workstreams/workstreams-header.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Settings2 } from 'lucide-react';
+import { WorkstreamConfigDialog } from './workstream-config-dialog';
+
+interface WorkstreamsHeaderProps {
+  showFilters: boolean;
+  storedProjectIds?: string[];
+  storedTimeRange?: { startDate: string; endDate: string };
+  filterDisplay?: React.ReactNode;
+}
+
+export function WorkstreamsHeader({
+  showFilters,
+  storedProjectIds,
+  storedTimeRange,
+  filterDisplay,
+}: WorkstreamsHeaderProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  if (!showFilters) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-4">
+        {filterDisplay}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setDialogOpen(true)}
+          title="Configure workstream generation filters"
+        >
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <WorkstreamConfigDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        currentFilters={
+          storedProjectIds || storedTimeRange
+            ? {
+                projectIds: storedProjectIds,
+                timeRange: storedTimeRange,
+              }
+            : undefined
+        }
+      />
+    </>
+  );
+}

--- a/apps/web/hooks/use-workstreams.ts
+++ b/apps/web/hooks/use-workstreams.ts
@@ -37,6 +37,20 @@ interface WorkstreamsResponse {
 }
 
 /**
+ * Request body for POST /api/workstreams/generate
+ * Includes optional filter parameters for clustering
+ */
+interface GenerateWorkstreamsRequest {
+  filters?: {
+    timeRange?: {
+      startDate: string; // ISO 8601 date (YYYY-MM-DD)
+      endDate: string; // ISO 8601 date (YYYY-MM-DD)
+    };
+    projectIds?: string[];
+  };
+}
+
+/**
  * Lightweight achievement summary for API responses
  * Includes only fields needed for UI display with project/company context
  */
@@ -168,13 +182,24 @@ export function useWorkstreamsActions() {
     };
   }, [generationStatus, isGenerating]);
 
-  const generateWorkstreams = async (): Promise<GenerateResult> => {
+  const generateWorkstreams = async (
+    filters?: GenerateWorkstreamsRequest['filters'],
+  ): Promise<GenerateResult> => {
     setIsGenerating(true);
     setGenerationStatus('Analyzing achievements...');
 
     try {
+      const requestBody: GenerateWorkstreamsRequest = {};
+      if (filters) {
+        requestBody.filters = filters;
+      }
+
       const response = await fetch('/api/workstreams/generate', {
         method: 'POST',
+        headers: requestBody.filters
+          ? { 'Content-Type': 'application/json' }
+          : undefined,
+        body: requestBody.filters ? JSON.stringify(requestBody) : undefined,
       });
 
       if (!response.ok) {

--- a/apps/web/test/api/workstreams-filters.test.ts
+++ b/apps/web/test/api/workstreams-filters.test.ts
@@ -1,0 +1,676 @@
+import { z } from 'zod';
+
+/**
+ * Validation Schema for Workstreams Generation Filters
+ * Extracted from apps/web/app/api/workstreams/generate/route.ts
+ * This is a copy for testing purposes
+ */
+const generateWithFiltersSchema = z
+  .object({
+    filters: z.optional(
+      z.object({
+        timeRange: z.optional(
+          z.object({
+            startDate: z
+              .string()
+              .datetime()
+              .or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)),
+            endDate: z
+              .string()
+              .datetime()
+              .or(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)),
+          }),
+        ),
+        projectIds: z.optional(z.array(z.string().uuid())),
+      }),
+    ),
+  })
+  .refine(
+    (data) => {
+      // Require both timeRange properties together or neither
+      if (data.filters?.timeRange) {
+        return (
+          data.filters.timeRange.startDate && data.filters.timeRange.endDate
+        );
+      }
+      return true;
+    },
+    {
+      message:
+        'Both startDate and endDate must be provided together for timeRange',
+      path: ['filters', 'timeRange'],
+    },
+  )
+  .refine(
+    (data) => {
+      // Validate startDate ≤ endDate
+      if (
+        data.filters?.timeRange?.startDate &&
+        data.filters.timeRange.endDate
+      ) {
+        const startDate = new Date(data.filters.timeRange.startDate);
+        const endDate = new Date(data.filters.timeRange.endDate);
+        return startDate <= endDate;
+      }
+      return true;
+    },
+    {
+      message: 'startDate must be less than or equal to endDate',
+      path: ['filters', 'timeRange'],
+    },
+  )
+  .refine(
+    (data) => {
+      // Validate time range does not exceed 24 months
+      if (
+        data.filters?.timeRange?.startDate &&
+        data.filters.timeRange.endDate
+      ) {
+        const startDate = new Date(data.filters.timeRange.startDate);
+        const endDate = new Date(data.filters.timeRange.endDate);
+        const monthsDiff =
+          (endDate.getFullYear() - startDate.getFullYear()) * 12 +
+          (endDate.getMonth() - startDate.getMonth());
+        return monthsDiff <= 24;
+      }
+      return true;
+    },
+    {
+      message: 'Time range cannot exceed 24 months',
+      path: ['filters', 'timeRange'],
+    },
+  );
+
+describe('Workstreams Filtering - Validation Schema (Task 6.1)', () => {
+  describe('Valid filter parameters', () => {
+    it('accepts no filters (backward compatible)', () => {
+      const result = generateWithFiltersSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts filters with timeRange only', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts filters with projectIds only', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: ['123e4567-e89b-12d3-a456-426614174000'],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts filters with both timeRange and projectIds', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+          projectIds: [
+            '123e4567-e89b-12d3-a456-426614174000',
+            '223e4567-e89b-12d3-a456-426614174001',
+          ],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts ISO 8601 datetime format', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10T10:30:00Z',
+            endDate: '2025-11-10T23:59:59Z',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts mixed datetime and date formats', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10T23:59:59Z',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts empty projectIds array', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: [],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts large array of projectIds', () => {
+      // Generate valid UUIDs in format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      const projectIds = Array.from({ length: 50 }, (_, i) => {
+        const num = String(i).padStart(12, '0');
+        return `550e8400-e29b-41d4-a716-${num}`;
+      });
+
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds,
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts equal start and end dates', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-05-10',
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Invalid date formats', () => {
+    it('rejects invalid date format (no dashes)', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '20250510',
+            endDate: '2025-11-10',
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes('startDate')),
+        ).toBe(true);
+      }
+    });
+
+    it('rejects garbage date strings', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: 'not-a-date',
+            endDate: '2025-11-10',
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects null dates', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: null,
+            endDate: '2025-11-10',
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Date range violations', () => {
+    it('rejects startDate > endDate', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-11-10',
+            endDate: '2025-05-10',
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) =>
+            i.message.includes('startDate must be'),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('rejects range exceeding 24 months', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2023-01-01',
+            endDate: '2025-02-01', // 25 months
+          },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.message.includes('24 months')),
+        ).toBe(true);
+      }
+    });
+
+    it('accepts exactly 24 months', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2023-01-01',
+            endDate: '2025-01-01', // Exactly 24 months
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Missing date parameters', () => {
+    it('rejects undefined endDate when startDate provided', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: undefined,
+          },
+        },
+      });
+      // Zod requires both fields if either is present
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.code === 'invalid_union' || i.path.includes('endDate'),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it('rejects empty timeRange object', () => {
+      // Empty timeRange object causes validation to fail
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          timeRange: {},
+        },
+      });
+      // Empty object means both fields are undefined, which fails the inner validation
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Invalid UUID formats in projectIds', () => {
+    it('rejects invalid UUID format', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: ['not-a-uuid'],
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects partial UUID', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: ['123e4567-e89b-12d3-a456'],
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects mix of valid and invalid UUIDs', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: ['123e4567-e89b-12d3-a456-426614174000', 'invalid-uuid'],
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts valid UUID v4 format', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: {
+          projectIds: [
+            '550e8400-e29b-41d4-a716-446655440000',
+            'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+          ],
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('accepts null filters value (should fail)', () => {
+      const result = generateWithFiltersSchema.safeParse({
+        filters: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('handles missing filters key gracefully', () => {
+      const result = generateWithFiltersSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe('Filter Change Detection Logic (Task 6.2)', () => {
+  /**
+   * Mock implementation of decideShouldReCluster with filter change detection
+   * Extracted from apps/web/lib/ai/workstreams.ts for testing
+   */
+  function decideShouldReCluster(
+    currentFilteredCount: number,
+    metadata: any,
+    currentFilters?: {
+      timeRange?: { startDate: Date; endDate: Date };
+      projectIds?: string[];
+    },
+  ) {
+    const RECLUSTER_PERCENTAGE_THRESHOLD = 0.1;
+    const RECLUSTER_ABSOLUTE_THRESHOLD = 50;
+    const RECLUSTER_TIME_THRESHOLD_DAYS = 30;
+
+    // Never clustered before
+    if (!metadata) {
+      return {
+        strategy: 'full',
+        reason: 'Initial clustering',
+      };
+    }
+
+    // Check if filters changed from previous clustering
+    if (metadata && currentFilters) {
+      const previousFilters = metadata.generationParams || {};
+
+      // Compare timeRange
+      const currentStartDate = currentFilters.timeRange?.startDate
+        ?.toISOString()
+        .split('T')[0];
+      const currentEndDate = currentFilters.timeRange?.endDate
+        ?.toISOString()
+        .split('T')[0];
+      const previousStartDate = previousFilters.timeRange?.startDate;
+      const previousEndDate = previousFilters.timeRange?.endDate;
+
+      const timeRangeChanged =
+        previousStartDate !== currentStartDate ||
+        previousEndDate !== currentEndDate;
+
+      // Compare projectIds
+      const projectIdsChanged =
+        JSON.stringify((previousFilters.projectIds || []).sort()) !==
+        JSON.stringify((currentFilters.projectIds || []).sort());
+
+      if (timeRangeChanged || projectIdsChanged) {
+        return {
+          strategy: 'full',
+          reason: 'Filter parameters changed from previous clustering',
+        };
+      }
+    }
+
+    // Calculate if we have 10% more achievements in the filtered set
+    const previousCount =
+      metadata.filteredAchievementCount ||
+      metadata.achievementCountAtLastClustering ||
+      0;
+    const achievementGrowthPercent =
+      previousCount > 0
+        ? (currentFilteredCount - previousCount) / previousCount
+        : 0;
+
+    if (achievementGrowthPercent >= RECLUSTER_PERCENTAGE_THRESHOLD) {
+      return {
+        strategy: 'full',
+        reason: `${(achievementGrowthPercent * 100).toFixed(1)}% growth in achievements`,
+      };
+    }
+
+    // Calculate if we have 50+ more achievements in the filtered set
+    const newAchievementCount = currentFilteredCount - previousCount;
+
+    if (newAchievementCount >= RECLUSTER_ABSOLUTE_THRESHOLD) {
+      return {
+        strategy: 'full',
+        reason: `${newAchievementCount} new achievements since last clustering`,
+      };
+    }
+
+    // Check if it's been more than 30 days
+    const lastClusteringTime = new Date(metadata.lastFullClusteringAt);
+    const daysSinceLastClustering =
+      (Date.now() - lastClusteringTime.getTime()) / (1000 * 60 * 60 * 24);
+
+    if (daysSinceLastClustering > RECLUSTER_TIME_THRESHOLD_DAYS) {
+      return {
+        strategy: 'full',
+        reason: `${daysSinceLastClustering.toFixed(1)} days since last clustering`,
+      };
+    }
+
+    return {
+      strategy: 'incremental',
+      reason: 'Growth is below thresholds and recent',
+    };
+  }
+
+  describe('Initial clustering', () => {
+    it('returns full when no metadata exists', () => {
+      const decision = decideShouldReCluster(100, null);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toBe('Initial clustering');
+    });
+  });
+
+  describe('Filter change detection', () => {
+    it('returns full when timeRange changed', () => {
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: new Date(),
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+        },
+      };
+
+      const currentFilters = {
+        timeRange: {
+          startDate: new Date('2025-01-10'),
+          endDate: new Date('2025-11-10'),
+        },
+      };
+
+      const decision = decideShouldReCluster(100, metadata, currentFilters);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toContain('Filter parameters changed');
+    });
+
+    it('returns full when projectIds changed', () => {
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: new Date(),
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          projectIds: ['project-1', 'project-2'],
+        },
+      };
+
+      const currentFilters = {
+        projectIds: ['project-1', 'project-3'],
+      };
+
+      const decision = decideShouldReCluster(100, metadata, currentFilters);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toContain('Filter parameters changed');
+    });
+
+    it('returns full when both timeRange and projectIds changed', () => {
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: new Date(),
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+          projectIds: ['project-1'],
+        },
+      };
+
+      const currentFilters = {
+        timeRange: {
+          startDate: new Date('2025-01-10'),
+          endDate: new Date('2025-11-10'),
+        },
+        projectIds: ['project-2'],
+      };
+
+      const decision = decideShouldReCluster(100, metadata, currentFilters);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toContain('Filter parameters changed');
+    });
+
+    it('returns full when filters removed after previous filter-based clustering', () => {
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: new Date(),
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+          projectIds: ['project-1'],
+        },
+      };
+
+      // Now requesting without filters
+      const currentFilters = {};
+
+      const decision = decideShouldReCluster(150, metadata, currentFilters);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toContain('Filter parameters changed');
+    });
+
+    it('returns incremental when filters identical to previous', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 10);
+
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: recentDate,
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+          projectIds: ['project-1'],
+        },
+      };
+
+      const currentFilters = {
+        timeRange: {
+          startDate: new Date('2025-05-10'),
+          endDate: new Date('2025-11-10'),
+        },
+        projectIds: ['project-1'],
+      };
+
+      const decision = decideShouldReCluster(105, metadata, currentFilters);
+      expect(decision.strategy).toBe('incremental');
+    });
+
+    it('returns incremental when projectIds order differs but content same', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 10);
+
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: recentDate,
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          projectIds: ['project-1', 'project-2', 'project-3'],
+        },
+      };
+
+      const currentFilters = {
+        projectIds: ['project-3', 'project-1', 'project-2'], // Same but different order
+      };
+
+      const decision = decideShouldReCluster(105, metadata, currentFilters);
+      expect(decision.strategy).toBe('incremental');
+    });
+  });
+
+  describe('Growth threshold detection', () => {
+    it('returns incremental when no filters provided and growth below threshold', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 10);
+
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: recentDate,
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+      };
+
+      const decision = decideShouldReCluster(105, metadata, undefined);
+      expect(decision.strategy).toBe('incremental');
+    });
+
+    it('returns full when filter params identical but growth exceeds 10%', () => {
+      const recentDate = new Date();
+      recentDate.setDate(recentDate.getDate() - 10);
+
+      const metadata = {
+        id: 'meta-1',
+        lastFullClusteringAt: recentDate,
+        achievementCountAtLastClustering: 100,
+        filteredAchievementCount: 100,
+        generationParams: {
+          timeRange: {
+            startDate: '2025-05-10',
+            endDate: '2025-11-10',
+          },
+        },
+      };
+
+      const currentFilters = {
+        timeRange: {
+          startDate: new Date('2025-05-10'),
+          endDate: new Date('2025-11-10'),
+        },
+      };
+
+      const decision = decideShouldReCluster(111, metadata, currentFilters);
+      expect(decision.strategy).toBe('full');
+      expect(decision.reason).toContain('growth in achievements');
+    });
+  });
+});

--- a/packages/database/src/migrations/0008_heavy_mysterio.sql
+++ b/packages/database/src/migrations/0008_heavy_mysterio.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WorkstreamMetadata" ADD COLUMN "generation_params" jsonb DEFAULT '{}'::jsonb NOT NULL;--> statement-breakpoint
+ALTER TABLE "WorkstreamMetadata" ADD COLUMN "filtered_achievement_count" integer DEFAULT 0 NOT NULL;

--- a/packages/database/src/migrations/meta/0008_snapshot.json
+++ b/packages/database/src/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2185 @@
+{
+  "id": "fda437c8-2cbd-4e7a-9a23-54a0aaee67f9",
+  "prevId": "4bb03842-60c8-4b78-95e1-67d8885f2fd1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.Account": {
+      "name": "Account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_idx": {
+          "name": "account_provider_idx",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Account_userId_User_id_fk": {
+          "name": "Account_userId_User_id_fk",
+          "tableFrom": "Account",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Achievement": {
+      "name": "Achievement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_source_id": {
+          "name": "unique_source_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standup_document_id": {
+          "name": "standup_document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_message_id": {
+          "name": "user_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_start": {
+          "name": "event_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_end": {
+          "name": "event_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_duration": {
+          "name": "event_duration",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "impact": {
+          "name": "impact",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "impact_source": {
+          "name": "impact_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "impact_updated_at": {
+          "name": "impact_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "workstream_id": {
+          "name": "workstream_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workstream_source": {
+          "name": "workstream_source",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'text-embedding-3-small'"
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "achievement_user_event_start_idx": {
+          "name": "achievement_user_event_start_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_workstream_id_idx": {
+          "name": "achievement_workstream_id_idx",
+          "columns": [
+            {
+              "expression": "workstream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_user_id_idx": {
+          "name": "achievement_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_event_start_idx": {
+          "name": "achievement_event_start_idx",
+          "columns": [
+            {
+              "expression": "event_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_user_source_idx": {
+          "name": "achievement_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_user_source_unique_idx": {
+          "name": "achievement_user_source_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unique_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievement_project_source_unique": {
+          "name": "achievement_project_source_unique",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "unique_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Achievement\".\"project_id\" IS NOT NULL AND \"Achievement\".\"unique_source_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Achievement_user_id_User_id_fk": {
+          "name": "Achievement_user_id_User_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Achievement_company_id_Company_id_fk": {
+          "name": "Achievement_company_id_Company_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Achievement_project_id_Project_id_fk": {
+          "name": "Achievement_project_id_Project_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Achievement_source_id_Source_id_fk": {
+          "name": "Achievement_source_id_Source_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Source",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Achievement_standup_document_id_StandupDocument_id_fk": {
+          "name": "Achievement_standup_document_id_StandupDocument_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "StandupDocument",
+          "columnsFrom": ["standup_document_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Achievement_user_message_id_UserMessage_id_fk": {
+          "name": "Achievement_user_message_id_UserMessage_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "UserMessage",
+          "columnsFrom": ["user_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Achievement_workstream_id_Workstream_id_fk": {
+          "name": "Achievement_workstream_id_Workstream_id_fk",
+          "tableFrom": "Achievement",
+          "tableTo": "Workstream",
+          "columnsFrom": ["workstream_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_user_id_idx": {
+          "name": "chat_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Chat_userId_User_id_fk": {
+          "name": "Chat_userId_User_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Company": {
+      "name": "Company",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_user_id_idx": {
+          "name": "company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Company_user_id_User_id_fk": {
+          "name": "Company_user_id_User_id_fk",
+          "tableFrom": "Company",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_user_id_idx": {
+          "name": "document_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_share_token_idx": {
+          "name": "document_share_token_idx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_User_id_fk": {
+          "name": "Document_userId_User_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_company_id_Company_id_fk": {
+          "name": "Document_company_id_Company_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "Document_chat_id_Chat_id_fk": {
+          "name": "Document_chat_id_Chat_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Chat",
+          "columnsFrom": ["chat_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_preferences": {
+      "name": "email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_types": {
+          "name": "email_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_preferences_user_id_User_id_fk": {
+          "name": "email_preferences_user_id_User_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_chat_id_idx": {
+          "name": "message_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3B82F6'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_remote_url": {
+          "name": "repo_remote_url",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_user_id_idx": {
+          "name": "project_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_user_id_User_id_fk": {
+          "name": "Project_user_id_User_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Project_company_id_Company_id_fk": {
+          "name": "Project_company_id_Company_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "Company",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Session": {
+      "name": "Session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Session_userId_User_id_fk": {
+          "name": "Session_userId_User_id_fk",
+          "tableFrom": "Session",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Session_token_unique": {
+          "name": "Session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Source": {
+      "name": "Source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "source_user_id_idx": {
+          "name": "source_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_project_id_idx": {
+          "name": "source_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_user_project_id_idx": {
+          "name": "source_user_project_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "source_user_id_archived_idx": {
+          "name": "source_user_id_archived_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Source_user_id_User_id_fk": {
+          "name": "Source_user_id_User_id_fk",
+          "tableFrom": "Source",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Source_project_id_Project_id_fk": {
+          "name": "Source_project_id_Project_id_fk",
+          "tableFrom": "Source",
+          "tableTo": "Project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Standup": {
+      "name": "Standup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "companyId": {
+          "name": "companyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_ids": {
+          "name": "project_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_mask": {
+          "name": "days_mask",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_time": {
+          "name": "meeting_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "standup_user_id_idx": {
+          "name": "standup_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Standup_userId_User_id_fk": {
+          "name": "Standup_userId_User_id_fk",
+          "tableFrom": "Standup",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Standup_companyId_Company_id_fk": {
+          "name": "Standup_companyId_Company_id_fk",
+          "tableFrom": "Standup",
+          "tableTo": "Company",
+          "columnsFrom": ["companyId"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StandupDocument": {
+      "name": "StandupDocument",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "standupId": {
+          "name": "standupId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wip": {
+          "name": "wip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achievements_summary": {
+          "name": "achievements_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wip_source": {
+          "name": "wip_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "achievements_summary_source": {
+          "name": "achievements_summary_source",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        }
+      },
+      "indexes": {
+        "standup_document_standup_id_idx": {
+          "name": "standup_document_standup_id_idx",
+          "columns": [
+            {
+              "expression": "standupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "standup_document_date_idx": {
+          "name": "standup_document_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "StandupDocument_standupId_Standup_id_fk": {
+          "name": "StandupDocument_standupId_Standup_id_fk",
+          "tableFrom": "StandupDocument",
+          "tableTo": "Standup",
+          "columnsFrom": ["standupId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "StandupDocument_userId_User_id_fk": {
+          "name": "StandupDocument_userId_User_id_fk",
+          "tableFrom": "StandupDocument",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Stream": {
+      "name": "Stream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Stream_chatId_Chat_id_fk": {
+          "name": "Stream_chatId_Chat_id_fk",
+          "tableFrom": "Stream",
+          "tableTo": "Chat",
+          "columnsFrom": ["chatId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Stream_id_pk": {
+          "name": "Stream_id_pk",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credentials'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"language\":\"en\",\"documentInstructions\":\"\"}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "level": {
+          "name": "level",
+          "type": "user_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "renewal_period": {
+          "name": "renewal_period",
+          "type": "renewal_period",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "last_payment": {
+          "name": "last_payment",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserMessage": {
+      "name": "UserMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserMessage_userId_User_id_fk": {
+          "name": "UserMessage_userId_User_id_fk",
+          "tableFrom": "UserMessage",
+          "tableTo": "User",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Workstream": {
+      "name": "Workstream",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#3B82F6'"
+        },
+        "centroid_embedding": {
+          "name": "centroid_embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "centroid_updated_at": {
+          "name": "centroid_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "achievement_count": {
+          "name": "achievement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workstream_user_id_idx": {
+          "name": "workstream_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workstream_user_archived_idx": {
+          "name": "workstream_user_archived_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Workstream_user_id_User_id_fk": {
+          "name": "Workstream_user_id_User_id_fk",
+          "tableFrom": "Workstream",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorkstreamMetadata": {
+      "name": "WorkstreamMetadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_clustering_at": {
+          "name": "last_full_clustering_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_count_at_last_clustering": {
+          "name": "achievement_count_at_last_clustering",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epsilon": {
+          "name": "epsilon",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_pts": {
+          "name": "min_pts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workstream_count": {
+          "name": "workstream_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "outlier_count": {
+          "name": "outlier_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "generation_params": {
+          "name": "generation_params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "filtered_achievement_count": {
+          "name": "filtered_achievement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WorkstreamMetadata_user_id_User_id_fk": {
+          "name": "WorkstreamMetadata_user_id_User_id_fk",
+          "tableFrom": "WorkstreamMetadata",
+          "tableTo": "User",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "WorkstreamMetadata_user_id_unique": {
+          "name": "WorkstreamMetadata_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.renewal_period": {
+      "name": "renewal_period",
+      "schema": "public",
+      "values": ["monthly", "yearly"]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": ["git", "github", "jira"]
+    },
+    "public.user_level": {
+      "name": "user_level",
+      "schema": "public",
+      "values": ["free", "basic", "pro", "demo"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["active", "banned", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1764009757077,
       "tag": "0007_yellow_nomad",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1764081167651,
+      "tag": "0008_heavy_mysterio",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -351,6 +351,20 @@ export const workstreamMetadata = pgTable('WorkstreamMetadata', {
   workstreamCount: integer('workstream_count').default(0),
   outlierCount: integer('outlier_count').default(0),
 
+  // Filter parameters from last clustering
+  generationParams: jsonb('generation_params')
+    .$type<{
+      timeRange?: { startDate: string; endDate: string };
+      projectIds?: string[];
+    }>()
+    .notNull()
+    .default({}),
+
+  // Count of achievements in filtered set at time of clustering
+  filteredAchievementCount: integer('filtered_achievement_count')
+    .notNull()
+    .default(0),
+
   // Auditing
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),


### PR DESCRIPTION
… to generation

Add optional request-time filtering to POST /api/workstreams/generate, allowing users to cluster achievements from specific time periods and/or selected projects. This enables more targeted clustering that reflects current work patterns and priorities, improving workstream thematic coherence.

**Key Changes:**
- **API Request**: Accept optional `filters` parameter with `timeRange` (startDate/endDate) and `projectIds` properties
- **Validation**: Validate date formats, date ranges, project UUIDs, and project ownership early in API route
- **Database Schema**: Add `generationParams` (JSONB) and `filteredAchievementCount` (INTEGER) columns to WorkstreamMetadata for filter tracking
- **Filtering Strategy**: Continue generating embeddings for ALL achievements (cost optimization), but cluster only filtered subset
- **Re-clustering Logic**: Detect filter parameter changes and trigger full re-clustering (not incremental) when filters differ from previous clustering
- **Auto-assignment**: Intelligently assign achievements outside current filter to nearest workstream centroids using existing distance thresholds
- **Response Format**: Include `appliedFilters`, `filteredAchievementCount`, and `autoAssignedOutsideFilters` in API responses for transparency
- **Backward Compatibility**: All filter parameters optional; requests without filters work exactly as before

**Technical Details:**
- Filtering applied AFTER embedding generation, before clustering (preserves cost optimization)
- Filtered achievement counts stored in metadata, enabling growth calculations relative to filtered datasets
- Filter changes detected by comparing current `filters` against metadata `generationParams`
- Minimum 20 achievement requirement applies to filtered set, not total set
- Auto-assignment ensures complete data coverage without re-clustering excluded achievements
- Uses existing cosine distance logic for centroid-based assignment

**Database Migration:**
- New migration adds two columns to WorkstreamMetadata with backward-compatible defaults

Closes #248