### PR TITLE
fix: correct dashboard stat widget arrow icons, text, and month comparisons

### DIFF
--- a/.claude/docs/tech/database.md
+++ b/.claude/docs/tech/database.md
@@ -890,6 +890,8 @@ export async function getAchievementStats({ userId, db = defaultDb }) {
 }
 ```
 
+**Month-over-Month Proration:** The `getAchievementStats` function prorates current month impact for fair comparison against previous full months. The formula projects current pace across the full month: `thisMonthImpact * (totalDaysInMonth / currentDayOfMonth)`. On day 1, actual values are used to avoid extreme 28-31x projections. This ensures growth percentages accurately reflect user performance rather than penalizing users for incomplete months.
+
 ### Date Range Queries
 ```typescript
 export async function generatePeriodSummary({

--- a/.claude/docs/tech/frontend-patterns.md
+++ b/.claude/docs/tech/frontend-patterns.md
@@ -721,6 +721,41 @@ interface StatProps {
 - **Project details page:** Project-specific achievement statistics
 - **Potential usage:** Companies page, reports page, any page with metrics
 
+### Growth Indicator Patterns
+
+Dashboard stat widgets use helper functions to dynamically render arrow icons and motivational text based on growth values. This ensures the UI accurately reflects whether metrics are trending up or down.
+
+**Icon Selection:**
+
+- `getGrowthIcon(growth, size)` - Returns `IconTrendingUp` (>= 0) or `IconTrendingDown` (< 0)
+- Size parameter: `'small'` (size-3) or `'large'` (size-4)
+
+**Motivational Text (Monthly):**
+
+`getMonthlyGrowthText(monthlyGrowth)` returns tier-based text:
+- `> 10%`: "Strong growth this month"
+- `> 0%`: "Growing impact this month"
+- `= 0%`: "Steady impact this month"
+- `> -10%`: "Slight dip this month"
+- `<= -10%`: "Impact declining this month"
+
+**Motivational Text (Weekly):**
+
+`getWeeklyGrowthText(weeklyGrowth)` returns tier-based text:
+- `> 10%`: "Excellent weekly performance"
+- `> 0%`: "Strong weekly performance"
+- `= 0%`: "Consistent weekly output"
+- `> -10%`: "Slower week than usual"
+- `<= -10%`: "Quiet week"
+
+**Footer Description (Weekly):**
+
+`getWeeklyFooterDescription(weeklyGrowth)` returns:
+- `>= 0%`: "Keep up the momentum!"
+- `< 0%`: "Every week is a fresh start"
+
+**Example Implementation:** See `apps/web/components/achievement-stats.tsx`
+
 ### Achievement Editing Pattern
 
 Achievement editing uses a parent-managed dialog with callback-based mode switching. Child components (AchievementsTable, AchievementItem) expose `onEdit` callbacks that parent components handle by opening AchievementDialog in edit mode with the pre-selected achievement. The pattern mirrors the impact rating inline editing callback approach.

--- a/apps/web/components/achievement-stats.tsx
+++ b/apps/web/components/achievement-stats.tsx
@@ -1,10 +1,46 @@
-import { IconTrendingUp, IconTarget, IconCalendar } from '@tabler/icons-react';
+import {
+  IconTrendingUp,
+  IconTrendingDown,
+  IconTarget,
+  IconCalendar,
+} from '@tabler/icons-react';
 import Link from 'next/link';
 import { auth } from '@/lib/better-auth/server';
 import { headers } from 'next/headers';
 
 import { getAchievementStats, getActiveProjectsCount } from '@bragdoc/database';
 import { Stat } from '@/components/shared/stat';
+
+function getGrowthIcon(growth: number, size: 'small' | 'large' = 'small') {
+  const className = size === 'small' ? 'size-3' : 'size-4';
+  return growth >= 0 ? (
+    <IconTrendingUp className={className} />
+  ) : (
+    <IconTrendingDown className={className} />
+  );
+}
+
+function getMonthlyGrowthText(monthlyGrowth: number): string {
+  if (monthlyGrowth > 10) return 'Strong growth this month';
+  if (monthlyGrowth > 0) return 'Growing impact this month';
+  if (monthlyGrowth === 0) return 'Steady impact this month';
+  if (monthlyGrowth > -10) return 'Slight dip this month';
+  return 'Impact declining this month';
+}
+
+function getWeeklyGrowthText(weeklyGrowth: number): string {
+  if (weeklyGrowth > 10) return 'Excellent weekly performance';
+  if (weeklyGrowth > 0) return 'Strong weekly performance';
+  if (weeklyGrowth === 0) return 'Consistent weekly output';
+  if (weeklyGrowth > -10) return 'Slower week than usual';
+  return 'Quiet week';
+}
+
+function getWeeklyFooterDescription(weeklyGrowth: number): string {
+  return weeklyGrowth >= 0
+    ? 'Keep up the momentum!'
+    : 'Every week is a fresh start';
+}
 
 export async function AchievementStats() {
   const session = await auth.api.getSession({
@@ -50,12 +86,12 @@ export async function AchievementStats() {
         label="Total Impact Points"
         value={displayStats.totalImpactPoints}
         badge={{
-          icon: <IconTrendingUp className="size-3" />,
+          icon: getGrowthIcon(displayStats.monthlyGrowth, 'small'),
           label: `${displayStats.monthlyGrowth > 0 ? '+' : ''}${displayStats.monthlyGrowth}%`,
         }}
         footerHeading={{
-          text: 'Growing impact this month',
-          icon: <IconTrendingUp className="size-4" />,
+          text: getMonthlyGrowthText(displayStats.monthlyGrowth),
+          icon: getGrowthIcon(displayStats.monthlyGrowth, 'large'),
         }}
         footerDescription={`Average ${displayStats.avgImpactPerAchievement} points per achievement`}
       />
@@ -64,14 +100,16 @@ export async function AchievementStats() {
         label="This Week's Impact"
         value={displayStats.thisWeekImpact}
         badge={{
-          icon: <IconTrendingUp className="size-3" />,
+          icon: getGrowthIcon(displayStats.weeklyGrowth, 'small'),
           label: `${displayStats.weeklyGrowth > 0 ? '+' : ''}${displayStats.weeklyGrowth}%`,
         }}
         footerHeading={{
-          text: 'Strong weekly performance',
-          icon: <IconTrendingUp className="size-4" />,
+          text: getWeeklyGrowthText(displayStats.weeklyGrowth),
+          icon: getGrowthIcon(displayStats.weeklyGrowth, 'large'),
         }}
-        footerDescription="Keep up the momentum!"
+        footerDescription={getWeeklyFooterDescription(
+          displayStats.weeklyGrowth,
+        )}
       />
 
       <Link href="/projects">

--- a/packages/database/src/queries.ts
+++ b/packages/database/src/queries.ts
@@ -1066,9 +1066,25 @@ export async function getAchievementStats({
 
     const thisMonthImpact = Number(thisMonthResult?.thisMonthImpact ?? 0);
     const lastMonthImpact = Number(lastMonthResult?.lastMonthImpact ?? 0);
+
+    // Calculate proration factor for fair month-over-month comparison
+    const currentDayOfMonth = now.getDate();
+    const totalDaysInMonth = new Date(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      0,
+    ).getDate();
+
+    // On day 1, use actual value to avoid extreme projections (28-31x)
+    // On day 2+, apply standard proration
+    const proratedThisMonthImpact =
+      currentDayOfMonth === 1
+        ? thisMonthImpact
+        : thisMonthImpact * (totalDaysInMonth / currentDayOfMonth);
+
     const monthlyGrowth =
       lastMonthImpact > 0
-        ? ((thisMonthImpact - lastMonthImpact) / lastMonthImpact) * 100
+        ? ((proratedThisMonthImpact - lastMonthImpact) / lastMonthImpact) * 100
         : 0;
 
     return {


### PR DESCRIPTION
The Achievement Dashboard stat widgets had three display issues: arrow icons always pointed upward regardless of growth direction, motivational footer text was static regardless of performance, and month-over-month comparisons were unfair because partial current months were compared against full previous months.

This change adds conditional rendering for `IconTrendingUp`/`IconTrendingDown` based on whether growth values are positive or negative. It introduces helper functions (`getMonthlyGrowthText`, `getWeeklyGrowthText`, `getWeeklyFooterDescription`) that return contextual text based on 5-tier thresholds (>10%, >0%, =0%, >-10%, <=-10%). The `getAchievementStats` query function now prorates current month impact using the formula `thisMonthImpact * (totalDaysInMonth / currentDayOfMonth)` before comparing against last month, with an edge case handler for day 1 to avoid extreme 28-31x projections.

Fixes #299