### PR TITLE
perf: strip embedding vectors from RSC payloads and remove duplicate fetches

### DIFF
--- a/apps/web/app/(app)/achievements/page.tsx
+++ b/apps/web/app/(app)/achievements/page.tsx
@@ -20,7 +20,7 @@ import { useAchievementMutations } from '@/hooks/use-achievement-mutations';
 import { useAchievements } from '@/hooks/use-achievements';
 import type {
   CreateAchievementRequest,
-  AchievementWithRelations,
+  AchievementWithRelationsUI,
 } from '@/lib/types/achievement';
 import { AppPage } from '@/components/shared/app-page';
 import { AppContent } from '@/components/shared/app-content';
@@ -46,10 +46,10 @@ export default function AchievementsPage() {
   const [editDialogOpen, setEditDialogOpen] = React.useState(false);
   const [editMode, setEditMode] = React.useState<'create' | 'edit'>('create');
   const [selectedAchievementForEdit, setSelectedAchievementForEdit] =
-    React.useState<AchievementWithRelations | null>(null);
+    React.useState<AchievementWithRelationsUI | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [selectedAchievementForDelete, setSelectedAchievementForDelete] =
-    React.useState<AchievementWithRelations | null>(null);
+    React.useState<AchievementWithRelationsUI | null>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
 
   // Table state
@@ -123,13 +123,13 @@ export default function AchievementsPage() {
     setGenerateDialogOpen(true);
   };
 
-  const handleEditClick = (achievement: AchievementWithRelations) => {
+  const handleEditClick = (achievement: AchievementWithRelationsUI) => {
     setSelectedAchievementForEdit(achievement);
     setEditMode('edit');
     setEditDialogOpen(true);
   };
 
-  const handleDeleteClick = (achievement: AchievementWithRelations) => {
+  const handleDeleteClick = (achievement: AchievementWithRelationsUI) => {
     setSelectedAchievementForDelete(achievement);
     setDeleteDialogOpen(true);
   };

--- a/apps/web/app/(app)/performance/[id]/[[...tab]]/page.tsx
+++ b/apps/web/app/(app)/performance/[id]/[[...tab]]/page.tsx
@@ -57,7 +57,12 @@ export default async function PerformanceReviewEditPage({
     }),
   ]);
 
-  const achievements = achievementsResult.achievements;
+  // Strip embedding vectors from achievements before passing to client component
+  // Embeddings are only used server-side for ML clustering, not needed in UI
+  const achievements = achievementsResult.achievements.map(
+    ({ embedding, embeddingModel, embeddingGeneratedAt, ...achievement }) =>
+      achievement,
+  );
 
   return (
     <AppPage>

--- a/apps/web/app/(app)/performance/[id]/performance-review-edit.tsx
+++ b/apps/web/app/(app)/performance/[id]/performance-review-edit.tsx
@@ -45,12 +45,12 @@ import type {
   Workstream,
   PerformanceReviewWithDocument,
 } from '@bragdoc/database';
-import type { AchievementWithRelations } from 'lib/types/achievement';
+import type { AchievementWithRelationsUI } from 'lib/types/achievement';
 
 interface PerformanceReviewEditProps {
   performanceReview: PerformanceReviewWithDocument;
   workstreams: Workstream[];
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   initialTab: string;
   performanceReviewId: string;
 }

--- a/apps/web/app/(app)/workstreams/page.tsx
+++ b/apps/web/app/(app)/workstreams/page.tsx
@@ -19,7 +19,7 @@ import {
 import { eq, and, gte, lte, count, inArray } from 'drizzle-orm';
 import { subMonths, startOfDay, endOfDay } from 'date-fns';
 import { headers } from 'next/headers';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 
 /**
  * Convert preset string to absolute dates
@@ -145,10 +145,10 @@ export default async function WorkstreamsPage({
     .leftJoin(project, eq(achievement.projectId, project.id))
     .where(and(...achievementConditions));
 
-  // Transform to AchievementWithRelations type
+  // Transform to AchievementWithRelationsUI type
   // Note: We're setting company and userMessage to null since we don't fetch them
   // We cast to any first to work around the type mismatch from partial selection
-  const allAchievements: AchievementWithRelations[] = achievementResults.map(
+  const allAchievements: AchievementWithRelationsUI[] = achievementResults.map(
     (row) =>
       ({
         ...row,
@@ -156,7 +156,7 @@ export default async function WorkstreamsPage({
         userMessage: null,
         // Handle nullable project from LEFT JOIN
         project: row.project?.id ? row.project : null,
-      }) as AchievementWithRelations,
+      }) as AchievementWithRelationsUI,
   );
 
   const showZeroState = userWorkstreams.length === 0;

--- a/apps/web/components/achievements-table.tsx
+++ b/apps/web/components/achievements-table.tsx
@@ -46,10 +46,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { AchievementItem } from '@/components/achievements/achievement-item';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 
 interface AchievementsTableProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   projects: Array<{ id: string; name: string; companyName: string | null }>;
   companies: Array<{ id: string; name: string }>;
   workstreams?: Array<{ id: string; name: string; color: string }>;
@@ -58,8 +58,8 @@ interface AchievementsTableProps {
   selectedAchievements: string[];
   onGenerateDocument: () => void; // Added onGenerateDocument prop
   projectId?: string; // Optional project ID to filter and hide project/company filters
-  onEdit?: (achievement: AchievementWithRelations) => void; // Added onEdit callback
-  onDelete?: (achievement: AchievementWithRelations) => void; // Added onDelete callback
+  onEdit?: (achievement: AchievementWithRelationsUI) => void; // Added onEdit callback
+  onDelete?: (achievement: AchievementWithRelationsUI) => void; // Added onDelete callback
 }
 
 function StarRating({

--- a/apps/web/components/achievements/AchievementDialog.tsx
+++ b/apps/web/components/achievements/AchievementDialog.tsx
@@ -30,7 +30,7 @@ import {
 } from 'components/ui/select';
 import { ImpactRating } from 'components/ui/impact-rating';
 import { z } from 'zod/v3';
-import type { Achievement } from 'lib/types/achievement';
+import type { AchievementUI } from 'lib/types/achievement';
 import { useCompanies } from 'hooks/use-companies';
 import { useProjects } from 'hooks/useProjects';
 import { useAchievements } from 'hooks/use-achievements';
@@ -66,7 +66,7 @@ interface AchievementDialogProps {
   mode: DialogMode;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  achievement?: Achievement;
+  achievement?: AchievementUI;
   onSubmit?: (data: FormValues) => void;
 }
 

--- a/apps/web/components/achievements/AchievementList.tsx
+++ b/apps/web/components/achievements/AchievementList.tsx
@@ -6,7 +6,7 @@ import { AchievementDialog } from './AchievementDialog';
 import { AchievementActions } from './achievement-actions';
 import { AchievementListSkeleton } from './achievement-list-skeleton';
 import type {
-  AchievementWithRelations as Achievement,
+  AchievementWithRelationsUI as Achievement,
   AchievementFilters as AchievementFiltersType,
 } from 'lib/types/achievement';
 import { useAchievements } from 'hooks/use-achievements';

--- a/apps/web/components/achievements/achievement-item.tsx
+++ b/apps/web/components/achievements/achievement-item.tsx
@@ -5,7 +5,7 @@ import { Badge } from 'components/ui/badge';
 import { Button } from 'components/ui/button';
 import { ImpactRating } from 'components/ui/impact-rating';
 import { WorkstreamBadge } from 'components/workstreams/workstream-badge';
-import type { AchievementWithRelations } from 'lib/types/achievement';
+import type { AchievementWithRelationsUI } from 'lib/types/achievement';
 import type { Workstream } from '@bragdoc/database';
 
 /**
@@ -13,8 +13,8 @@ import type { Workstream } from '@bragdoc/database';
  *
  * @param achievement - The achievement to display
  * @param onImpactChange - Optional callback when impact rating changes
- * @param onEdit - Optional callback when edit button is clicked
- * @param onDelete - Optional callback when delete button is clicked
+ * @param onEdit - Optional callback when edit button is clicked (accepts any achievement-like object)
+ * @param onDelete - Optional callback when delete button is clicked (accepts any achievement-like object)
  * @param readOnly - Whether to disable impact rating changes
  * @param showSourceBadge - Whether to show the impact source badge
  * @param linkToAchievements - Whether achievement title links to achievements page
@@ -22,10 +22,12 @@ import type { Workstream } from '@bragdoc/database';
  * @param onWorkstreamChange - Optional callback when workstream badge is clicked
  */
 interface AchievementItemProps {
-  achievement: AchievementWithRelations;
+  achievement: AchievementWithRelationsUI;
   onImpactChange?: (id: string, impact: number) => void;
-  onEdit?: (achievement: AchievementWithRelations) => void;
-  onDelete?: (achievement: AchievementWithRelations) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onEdit?: (achievement: any) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onDelete?: (achievement: any) => void;
   readOnly?: boolean;
   showSourceBadge?: boolean;
   linkToAchievements?: boolean;

--- a/apps/web/components/achievements/delete-achievement-dialog.tsx
+++ b/apps/web/components/achievements/delete-achievement-dialog.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTitle,
 } from 'components/ui/alert-dialog';
 import { toast } from 'sonner';
-import type { AchievementWithRelations } from 'lib/types/achievement';
+import type { AchievementWithRelationsUI } from 'lib/types/achievement';
 
 /**
  * DeleteAchievementDialog - Confirmation dialog for deleting an achievement
@@ -29,7 +29,7 @@ import type { AchievementWithRelations } from 'lib/types/achievement';
 interface DeleteAchievementDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  achievement: AchievementWithRelations | null;
+  achievement: AchievementWithRelationsUI | null;
   onConfirm: () => Promise<void>;
   isDeleting?: boolean;
 }

--- a/apps/web/components/dashboard/activity-stream.tsx
+++ b/apps/web/components/dashboard/activity-stream.tsx
@@ -7,16 +7,16 @@ import { AchievementItem } from 'components/achievements/achievement-item';
 import { AchievementDialog } from 'components/achievements/AchievementDialog';
 import { useAchievementMutations } from '@/hooks/use-achievement-mutations';
 import { useAchievements } from '@/hooks/use-achievements';
-import type { AchievementWithRelations } from 'lib/types/achievement';
+import type { AchievementWithRelationsUI } from 'lib/types/achievement';
 
 interface ActivityStreamProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
 }
 
 export function ActivityStream({ achievements }: ActivityStreamProps) {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [editingAchievement, setEditingAchievement] =
-    useState<AchievementWithRelations | null>(null);
+    useState<AchievementWithRelationsUI | null>(null);
   const { updateAchievement, deleteAchievement } = useAchievementMutations();
   const { mutate } = useAchievements();
 
@@ -50,7 +50,7 @@ export function ActivityStream({ achievements }: ActivityStreamProps) {
     }
   };
 
-  const handleEdit = (achievement: AchievementWithRelations) => {
+  const handleEdit = (achievement: AchievementWithRelationsUI) => {
     setEditingAchievement(achievement);
   };
 
@@ -67,7 +67,7 @@ export function ActivityStream({ achievements }: ActivityStreamProps) {
     }
   };
 
-  const handleDelete = async (achievement: AchievementWithRelations) => {
+  const handleDelete = async (achievement: AchievementWithRelationsUI) => {
     setActionLoading(`delete-${achievement.id}`);
     try {
       await deleteAchievement(achievement.id);

--- a/apps/web/components/generate-document-dialog.tsx
+++ b/apps/web/components/generate-document-dialog.tsx
@@ -16,7 +16,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
 import { FileText, Calendar, BarChart3, Edit3, Loader2 } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 
 // Backend API types
 type DocumentType =
@@ -94,7 +94,7 @@ function generateDocumentTitle(frontendType: string): string {
 interface GenerateDocumentDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  selectedAchievements: AchievementWithRelations[];
+  selectedAchievements: AchievementWithRelationsUI[];
 }
 
 const documentTypes = [

--- a/apps/web/components/performance-review/achievements-section.tsx
+++ b/apps/web/components/performance-review/achievements-section.tsx
@@ -7,11 +7,11 @@ import { AchievementDialog } from 'components/achievements/AchievementDialog';
 import { DeleteAchievementDialog } from 'components/achievements/delete-achievement-dialog';
 import { useAchievementMutations } from '@/hooks/use-achievement-mutations';
 import { useAchievements } from '@/hooks/use-achievements';
-import type { AchievementWithRelations } from 'lib/types/achievement';
+import type { AchievementWithRelationsUI } from 'lib/types/achievement';
 import type { Workstream } from '@bragdoc/database';
 
 interface AchievementsSectionProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   workstreams?: Workstream[];
 }
 
@@ -30,9 +30,9 @@ export function AchievementsSection({
 }: AchievementsSectionProps) {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [editingAchievement, setEditingAchievement] =
-    useState<AchievementWithRelations | null>(null);
+    useState<AchievementWithRelationsUI | null>(null);
   const [deletingAchievement, setDeletingAchievement] =
-    useState<AchievementWithRelations | null>(null);
+    useState<AchievementWithRelationsUI | null>(null);
   const { updateAchievement, deleteAchievement } = useAchievementMutations();
   const { mutate } = useAchievements();
 
@@ -73,7 +73,7 @@ export function AchievementsSection({
     }
   };
 
-  const handleEdit = (achievement: AchievementWithRelations) => {
+  const handleEdit = (achievement: AchievementWithRelationsUI) => {
     setEditingAchievement(achievement);
   };
 
@@ -90,7 +90,7 @@ export function AchievementsSection({
     }
   };
 
-  const handleDelete = (achievement: AchievementWithRelations) => {
+  const handleDelete = (achievement: AchievementWithRelationsUI) => {
     setDeletingAchievement(achievement);
   };
 

--- a/apps/web/components/performance-review/performance-review-achievements-table.tsx
+++ b/apps/web/components/performance-review/performance-review-achievements-table.tsx
@@ -43,12 +43,11 @@ import { AchievementDialog } from '@/components/achievements/AchievementDialog';
 import { DeleteAchievementDialog } from '@/components/achievements/delete-achievement-dialog';
 import { WorkstreamBadge } from '@/components/workstreams/workstream-badge';
 import { useAchievementMutations } from '@/hooks/use-achievement-mutations';
-import { useAchievements } from '@/hooks/use-achievements';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 import type { Workstream } from '@bragdoc/database';
 
 interface PerformanceReviewAchievementsTableProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   workstreams?: Workstream[];
 }
 
@@ -101,12 +100,12 @@ export function PerformanceReviewAchievementsTable({
   const [displayCount, setDisplayCount] = React.useState(20);
   const [actionLoading, setActionLoading] = React.useState<string | null>(null);
   const [editingAchievement, setEditingAchievement] =
-    React.useState<AchievementWithRelations | null>(null);
+    React.useState<AchievementWithRelationsUI | null>(null);
   const [deletingAchievement, setDeletingAchievement] =
-    React.useState<AchievementWithRelations | null>(null);
+    React.useState<AchievementWithRelationsUI | null>(null);
 
+  // useAchievementMutations handles cache invalidation automatically
   const { updateAchievement, deleteAchievement } = useAchievementMutations();
-  const { mutate } = useAchievements();
 
   // Create a map of workstreams by ID for quick lookup
   const workstreamMap = React.useMemo(() => {
@@ -167,9 +166,6 @@ export function PerformanceReviewAchievementsTable({
         impactSource: 'user',
         impactUpdatedAt: new Date(),
       });
-
-      // Refresh achievements data
-      mutate();
     } catch (error) {
       console.error('Error updating impact:', error);
     } finally {
@@ -177,7 +173,7 @@ export function PerformanceReviewAchievementsTable({
     }
   };
 
-  const handleEdit = (achievement: AchievementWithRelations) => {
+  const handleEdit = (achievement: AchievementWithRelationsUI) => {
     setEditingAchievement(achievement);
   };
 
@@ -187,14 +183,13 @@ export function PerformanceReviewAchievementsTable({
     setActionLoading(`update-${editingAchievement.id}`);
     try {
       await updateAchievement(editingAchievement.id, data);
-      mutate();
       setEditingAchievement(null);
     } finally {
       setActionLoading(null);
     }
   };
 
-  const handleDelete = (achievement: AchievementWithRelations) => {
+  const handleDelete = (achievement: AchievementWithRelationsUI) => {
     setDeletingAchievement(achievement);
   };
 
@@ -204,7 +199,6 @@ export function PerformanceReviewAchievementsTable({
     setActionLoading(`delete-${deletingAchievement.id}`);
     try {
       await deleteAchievement(deletingAchievement.id);
-      mutate();
       setDeletingAchievement(null);
     } finally {
       setActionLoading(null);

--- a/apps/web/components/performance-review/workstreams-timeline.tsx
+++ b/apps/web/components/performance-review/workstreams-timeline.tsx
@@ -10,11 +10,11 @@ import { WorkstreamSelectionZeroState } from '@/components/workstreams/workstrea
 import { WorkstreamDialog } from '@/components/workstreams/workstream-dialog';
 import { useWorkstreamsActions } from '@/hooks/use-workstreams';
 import type { Workstream } from '@bragdoc/database';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 
 interface WorkstreamsTimelineProps {
   workstreams: Workstream[];
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   startDate: Date;
   endDate: Date;
 }

--- a/apps/web/components/recent-achievements-table.tsx
+++ b/apps/web/components/recent-achievements-table.tsx
@@ -29,13 +29,13 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 import { AchievementDialog } from '@/components/achievements/AchievementDialog';
 import { DeleteAchievementDialog } from '@/components/achievements/delete-achievement-dialog';
 import { useAchievementActions } from '@/hooks/use-achievement-actions';
 
 interface RecentAchievementsTableProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   onRefresh?: () => Promise<void>;
 }
 

--- a/apps/web/components/weekly-impact-chart.tsx
+++ b/apps/web/components/weekly-impact-chart.tsx
@@ -11,7 +11,7 @@ import {
 } from 'date-fns';
 
 import { useIsMobile } from '@/hooks/use-mobile';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 import {
   Card,
   CardAction,
@@ -38,7 +38,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 // Dynamic chart config will be computed from projects
 
 interface WeeklyImpactChartProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
 }
 
 export function WeeklyImpactChart({ achievements }: WeeklyImpactChartProps) {

--- a/apps/web/components/workstreams/workstream-achievements-table.tsx
+++ b/apps/web/components/workstreams/workstream-achievements-table.tsx
@@ -23,11 +23,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 import type { Workstream } from '@bragdoc/database';
 
 interface WorkstreamAchievementsTableProps {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   workstreams: Workstream[];
   selectedWorkstreamId: string | null;
   onGenerateWorkstreams?: () => void;
@@ -83,7 +83,7 @@ export function WorkstreamAchievementsTable({
   };
 
   // Helper to get the current impact value (local override or original)
-  const getImpact = (achievement: AchievementWithRelations) => {
+  const getImpact = (achievement: AchievementWithRelationsUI) => {
     return impactOverrides[achievement.id] ?? achievement.impact ?? 2;
   };
 
@@ -115,8 +115,8 @@ export function WorkstreamAchievementsTable({
     // Split into in-range and older achievements if date range is specified
     if (startDate) {
       const startTime = startDate.getTime();
-      const inRange: AchievementWithRelations[] = [];
-      const older: AchievementWithRelations[] = [];
+      const inRange: AchievementWithRelationsUI[] = [];
+      const older: AchievementWithRelationsUI[] = [];
 
       for (const achievement of sorted) {
         const achievementDate = achievement.eventStart
@@ -179,7 +179,7 @@ export function WorkstreamAchievementsTable({
 
   // Helper to render achievement row (desktop)
   const renderAchievementRow = (
-    achievement: AchievementWithRelations,
+    achievement: AchievementWithRelationsUI,
     isOlder = false,
   ) => (
     <TableRow key={achievement.id} className={isOlder ? 'opacity-50' : ''}>
@@ -244,7 +244,7 @@ export function WorkstreamAchievementsTable({
 
   // Helper to render achievement card (mobile)
   const renderAchievementCard = (
-    achievement: AchievementWithRelations,
+    achievement: AchievementWithRelationsUI,
     isOlder = false,
   ) => (
     <div

--- a/apps/web/components/workstreams/workstreams-client.tsx
+++ b/apps/web/components/workstreams/workstreams-client.tsx
@@ -9,11 +9,11 @@ import { WorkstreamDialog } from './workstream-dialog';
 import { useWorkstreamsActions } from '@/hooks/use-workstreams';
 import { startOfDay, endOfDay, subMonths } from 'date-fns';
 import type { Workstream } from '@bragdoc/database';
-import type { AchievementWithRelations } from '@/lib/types/achievement';
+import type { AchievementWithRelationsUI } from '@/lib/types/achievement';
 
 interface WorkstreamsClientProps {
   workstreams: Workstream[];
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   initialPreset: string;
 }
 

--- a/apps/web/hooks/use-achievement-actions.ts
+++ b/apps/web/hooks/use-achievement-actions.ts
@@ -11,7 +11,7 @@ import { toast } from 'sonner';
  * deleting achievements across components. Use with AchievementDialog and
  * DeleteAchievementDialog components to create fully functional edit/delete flows.
  *
- * Works with both AchievementWithRelations and partial achievement types.
+ * Works with both AchievementWithRelationsUI and partial achievement types.
  *
  * @param options - Hook configuration options
  * @param options.onRefresh - Optional callback to refresh achievements list after successful edits/deletes
@@ -67,12 +67,12 @@ export function useAchievementActions(options?: {
 }) {
   const router = useRouter();
 
-  // Edit dialog state - use any to support both AchievementWithRelations and partial types
+  // Edit dialog state - use any to support both AchievementWithRelationsUI and partial types
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [achievementToEdit, setAchievementToEdit] = useState<any>(null);
   const [isEditingAchievement, setIsEditingAchievement] = useState(false);
 
-  // Delete dialog state - use any to support both AchievementWithRelations and partial types
+  // Delete dialog state - use any to support both AchievementWithRelationsUI and partial types
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [achievementToDelete, setAchievementToDelete] = useState<any>(null);
   const [isDeletingAchievement, setIsDeletingAchievement] = useState(false);

--- a/apps/web/hooks/use-achievements.ts
+++ b/apps/web/hooks/use-achievements.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import useSWR from 'swr';
 import type {
-  AchievementWithRelations,
+  AchievementWithRelationsUI,
   CreateAchievementRequest,
 } from 'lib/types/achievement';
 
@@ -22,7 +22,7 @@ interface UseAchievementsOptions {
 }
 
 interface AchievementsResponse {
-  achievements: AchievementWithRelations[];
+  achievements: AchievementWithRelationsUI[];
   pagination: {
     total: number;
     page: number;

--- a/apps/web/lib/types/achievement.ts
+++ b/apps/web/lib/types/achievement.ts
@@ -12,12 +12,24 @@ export type Company = InferSelectModel<typeof company>;
 export type Project = InferSelectModel<typeof project>;
 export type UserMessage = InferSelectModel<typeof userMessage>;
 
+// Base achievement type for UI - excludes embedding vectors (only used server-side for ML)
+export type AchievementUI = Omit<
+  Achievement,
+  'embedding' | 'embeddingModel' | 'embeddingGeneratedAt'
+>;
+
 // Type with resolved relations
 export type AchievementWithRelations = Achievement & {
   company: Company | null;
   project: Project | null;
   userMessage: UserMessage | null;
 };
+
+// Type for UI components - excludes embedding vectors (only used server-side for ML)
+export type AchievementWithRelationsUI = Omit<
+  AchievementWithRelations,
+  'embedding' | 'embeddingModel' | 'embeddingGeneratedAt'
+>;
 
 // Duration enum matching the database schema
 export const EventDuration = {


### PR DESCRIPTION
- Create AchievementUI and AchievementWithRelationsUI types that exclude
    embedding fields (embedding, embeddingModel, embeddingGeneratedAt)
  - Update all UI components to use the new types since embeddings are only
    needed server-side for ML clustering
  - Strip embeddings in server component before passing to client, reducing
    RSC payload from ~1.3MB to ~100-200KB for 155 achievements
  - Remove unnecessary useAchievements() hook call in performance review
    achievements table that was triggering duplicate API fetches