### PR TITLE
fix: disable blockJS in next-mdx-remote v6 for blog posts

### DIFF
--- a/apps/marketing/app/blog/[slug]/page.tsx
+++ b/apps/marketing/app/blog/[slug]/page.tsx
@@ -150,6 +150,7 @@ export default async function BlogPostPage({
             <div className="prose prose-lg dark:prose-invert max-w-none">
               <MDXRemote
                 source={post.content}
+                options={{ blockJS: false }}
                 components={{
                   DemoCTA,
                   SignUpCTA,


### PR DESCRIPTION
## Summary

- Fixes Cloudflare build failure caused by next-mdx-remote v6 (bumped in #377) which defaults `blockJS: true`, stripping JS expressions from MDX content
- Five blog posts using `<ImageGallery images={[...]}/>` with inline array props were broken, causing `TypeError: Cannot read properties of undefined (reading 'map')` during static page generation
- Adds `options={{ blockJS: false }}` to the `MDXRemote` component — safe since we control all blog content

## Test plan

- [x] `pnpm --filter=@bragdoc/marketing build` succeeds locally with all 50 static pages generated
- [ ] Cloudflare deploy completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)