### PR TITLE
feat: add blog post - Duolingo Backed Down on AI Reviews. Others Didn't.

### DIFF
--- a/.claude/docs/processes/blog-rules.md
+++ b/.claude/docs/processes/blog-rules.md
@@ -33,9 +33,11 @@ Blog posts are written as .mdx files in the apps/marketing/content/blog director
 ### Titles and Headlines
 
 - Titles should be 50-60 characters to display properly in search results
+- **Include long-tail keyword in the title when possible** (e.g., "How to Track Accomplishments for Performance Reviews")
 - Include primary keyword naturally in the title, preferably near the beginning
 - Make titles compelling and click-worthy while accurately representing content
 - Use H1 for the main title (only one per page), H2 for major sections, H3 for subsections
+- If title is news-driven (e.g., "Meta Built an AI..."), ensure at least one H2 contains a long-tail keyword phrase
 
 ### Content Structure
 
@@ -47,10 +49,20 @@ Blog posts are written as .mdx files in the apps/marketing/content/blog director
 
 ### Keywords and Semantic SEO
 
-- Focus on one primary keyword per post, with 2-3 related secondary keywords
+**CRITICAL: Always Optimize for Long-Tail Keywords**
+
+- **Primary focus: Long-tail keywords (3-5+ words)** that capture specific user intent and search queries
+- Every blog post MUST target at least one long-tail keyword phrase in the title or primary H2
+- Long-tail examples: "how to track accomplishments for performance review", "document work achievements automatically", "remember what I did for performance review"
+- Avoid generic/competitive keywords like "performance reviews" or "career growth" as primary targets
+- Test keyword in Google - if first page is dominated by huge sites (LinkedIn, Indeed, Forbes), pick more specific long-tail
+
+**Keyword Strategy:**
+- Focus on one primary long-tail keyword per post (3-5 words minimum)
+- Include 2-3 related secondary long-tail keywords
 - Use keywords naturally - never force or stuff them
 - Include semantic variations and related terms (e.g., "brag document," "work achievements," "career tracking")
-- Target long-tail keywords that match user intent (e.g., "how to track work achievements" vs. "work tracking")
+- Target user intent: "how to", "why", "what to", "best way to" phrases perform well
 
 ### Meta Elements
 

--- a/apps/marketing/content/blog/duolingo-reversed-ai-reviews-competitors-doubled-down.mdx
+++ b/apps/marketing/content/blog/duolingo-reversed-ai-reviews-competitors-doubled-down.mdx
@@ -1,0 +1,53 @@
+---
+title: "Duolingo Backed Down on AI Reviews. Others Didn't."
+description: "Duolingo reversed its AI performance review policy after backlash. But Meta, Amazon, and Google doubled down. Here's what that divide reveals about the future of performance reviews."
+date: "2026-04-20"
+author: "BragDoc Team"
+tags: ["performance-reviews", "ai-tools", "career-growth", "documentation", "tech-industry"]
+image: "/images/blog/duolingo-ai-reversal/duolingo-ai-reversal-hero.svg"
+imageAlt: "Two diverging paths: one company reversing course, others pressing forward with AI-driven performance evaluation"
+published: true
+canonical_url: "https://www.bragdoc.ai/blog/duolingo-reversed-ai-reviews-competitors-doubled-down"
+---
+
+In early April 2026, Duolingo CEO Luis von Ahn reversed course on a policy he'd announced just one year earlier: employees would no longer be evaluated on their AI usage in performance reviews.
+
+The reversal came after pushback from employees ("Are you just forcing us to use AI for AI's sake?") and users threatening to delete the app. [Von Ahn acknowledged it on the Silicon Valley Girl podcast](https://fortune.com/2026/04/13/duolingo-ceo-luis-von-ahn-ai-usage-requirement-employee-performance-evaluations/): "The most important thing in your performance is that you are doing whatever your job is as well as possible. A lot of times, AI can help you with that, but if it can't, I'm not going to force you."
+
+Reasonable. Measured. And almost completely out of step with what every other large tech company is doing.
+
+## The Divide
+
+Duolingo's reversal is notable precisely because it's an exception. While Duolingo backed off measuring AI *tool adoption*, Meta, Amazon, and Google are doing something subtly but importantly different: they're measuring *output*.
+
+The distinction matters. Duolingo was tracking whether you used AI. Meta, Amazon, and Google are tracking what you shipped, what changed, what impact resulted — and whether you can document it.
+
+That's a much harder thing to push back against, because it's not arbitrary. It's outcome-based.
+
+We've written before about [how this output-over-effort shift has been building since 2025](/blog/output-over-effort-changes-everything) — Meta's Checkpoint system, Amazon's Forte framework, X's weekly accomplishment requirements. And in [our analysis of Meta's AI review assistant](/blog/meta-ai-performance-reviews-missing-piece), we covered how even the companies deploying AI to help write reviews haven't solved the underlying input problem.
+
+The Duolingo story adds a new dimension: companies that tried to mandate AI *usage* are running into cultural resistance. Companies that mandate AI *impact documentation* — showing how your work changed things — aren't.
+
+## Why This Distinction Matters for Your Career
+
+The lesson from Duolingo's reversal isn't "companies are backing down on AI reviews." It's that you can't mandate a tool. You can mandate a result.
+
+Duolingo tried to evaluate whether you used AI. That's a process metric. Employees and users rightly questioned whether a tool mandate had anything to do with the quality of the work.
+
+Meta, Amazon, and Google aren't making that mistake. They're evaluating the outcome. Did you ship something that mattered? Can you prove it? That question isn't going away — regardless of whether you used AI to do it.
+
+This puts the burden back on documentation. Not "did you use AI" but "can you demonstrate what you accomplished?" The [recent formalization of Amazon's Forte accomplishments requirement](/blog/amazon-forte-requires-accomplishments) is the clearest example: [350,000 employees now need to submit 3–5 specific, documented accomplishments per review cycle](https://www.hrgrapevine.com/us/content/article/2026-01-08-amazon-asks-employees-to-list-achievements-as-part-of-new-review-process). No accomplishments, no credit.
+
+## The Thing Duolingo Actually Exposed
+
+Duolingo's experiment revealed a failure mode that applies to any top-down performance metric: when companies measure the wrong proxy, people game it or resist it.
+
+The right proxy isn't tool adoption. It's impact.
+
+And here's the uncomfortable part: most engineers don't document their impact as they go. Which means when a company formalizes outcome-based reviews — which they will, because [the industry trend is clear](/blog/output-over-effort-changes-everything) — the engineers who've been keeping a running record of what they shipped and what changed will have a significant advantage over those who haven't.
+
+Duolingo walked back the AI mandate. The documentation mandate, at every other large tech company, is still standing. [CNBC noted in February 2026](https://www.cnbc.com/2026/02/10/tech-companies-like-amazon-and-meta-are-tightening-their-performance-reviews-heres-what-that-could-signal-according-to-experts.html) that Big Tech's tightening of performance reviews isn't a coincidence — it's a structural shift. That hasn't reversed.
+
+If you want to build the habit — or automate the routine parts by connecting to your Git history — that's what [BragDoc](/) does.
+
+<SignUpCTA />

--- a/apps/marketing/content/blog/meta-ai-performance-reviews-missing-piece.mdx
+++ b/apps/marketing/content/blog/meta-ai-performance-reviews-missing-piece.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Meta Built an AI to Write Reviews. You Still Need to Remember."
-description: "Meta built an AI to help write performance reviews. But their system still requires you to manually input your accomplishments. Here's what they're missing."
+description: "Meta built an AI to help write performance reviews. But you still need to remember what you accomplished. Learn how to track work achievements automatically."
 date: "2026-02-23"
 author: "BragDoc Team"
 tags: ["performance-reviews", "ai-tools", "meta", "achievement-tracking", "documentation"]
@@ -34,9 +34,9 @@ Based on available reports, the workflow appears to work like this:
 
 Notice what's missing? Steps 0 through 1. The part where you actually remember what you did.
 
-## The Real Bottleneck in Performance Reviews
+## How to Remember Accomplishments for Performance Reviews
 
-If you've ever prepared a performance review, you know the hard part isn't writing eloquent prose. The hard part is answering a much simpler question: what did I actually accomplish in the last six months?
+If you've ever prepared a performance review, you know the hard part isn't writing eloquent prose. The hard part is answering a much simpler question: what did I actually accomplish in the last six months? This is the universal challenge: how to remember accomplishments for performance reviews when months have passed.
 
 You shipped code every day. You closed tickets. You reviewed PRs. You fixed bugs. You participated in design discussions. You mentored teammates. You made architectural decisions. All of this happened, but can you list it six months later?
 
@@ -46,7 +46,7 @@ You remember the big projects. The feature launch that took three months. The in
 
 That refactor in April? Gone. The performance optimization in May? Fuzzy. The bug fix that saved a customer from churning? You know you did something like that, but when was it exactly?
 
-This is the documentation problem that Meta's AI doesn't solve. You can have the most sophisticated AI writing assistant in the world, but if you forget to mention the work in the first place, it never makes it into your review.
+This is the documentation problem that Meta's AI doesn't solve. You can have the most sophisticated AI writing assistant in the world, but if you can't remember what you accomplished, it never makes it into your review. The challenge isn't writing—it's capturing and tracking work achievements before memory fades.
 
 ## Meta's Approach Still Requires Manual Input
 
@@ -68,7 +68,7 @@ Your actual work—the code you shipped, the PRs you reviewed, the commits you m
 
 ## The Missing Layer: Automatic Achievement Capture
 
-This is where the automation gap becomes obvious. Meta employees still need to do the same thing everyone else does: manually compile their accomplishments before they can use the AI writing tool.
+This is where the automation gap becomes obvious. Meta employees still need to do the same thing everyone else does: manually track their accomplishments and compile them from memory before they can use the AI writing tool.
 
 Compare this to a system that starts with your actual work:
 
@@ -102,9 +102,9 @@ But they solved the wrong bottleneck. The hard part isn't writing polished prose
 
 Put differently: Meta built a better typewriter when what employees needed was a better notebook.
 
-## What Actually Solves This
+## How to Track Work Achievements Automatically
 
-The solution isn't better AI writing. It's automatic capture.
+The solution to tracking work achievements isn't better AI writing. It's automatic capture.
 
 Your Git history already contains a complete record of your technical work. Every commit. Every PR. Every code review. Timestamped. With context. With diffs showing exactly what changed.
 
@@ -112,7 +112,7 @@ This is objective documentation that requires zero additional effort. You create
 
 The problem isn't the data—it's extracting meaningful achievements from it. That's where [automated achievement tracking](/blog/why-developers-need-automated-brag-docs) changes the equation.
 
-Instead of manually compiling your work six months later, the system processes your Git history continuously. As you work. Commit by commit. PR by PR. When review time comes, you have a comprehensive list of what you actually accomplished.
+Instead of manually compiling your work six months later, the system processes your Git history continuously. As you work. Commit by commit. PR by PR. When review time comes, you have a comprehensive record documenting every work achievement.
 
 That's when an AI writing assistant becomes truly valuable. It can help you synthesize that complete record into compelling review language. But it needs the input first.
 
@@ -140,7 +140,7 @@ Then use AI to polish the writing. Start with complete data. Everything else is 
 
 If you're using Meta's AI Performance Assistant—or any similar tool—make sure you're feeding it complete information. The AI can only work with what you give it.
 
-That means capturing your work continuously. Git commits, PRs you created, issues you closed—all documented as it happens.
+That means documenting work achievements continuously. Git commits, PRs you created, issues you closed—all captured as it happens so you never have to remember accomplishments from memory.
 
 That's what we built [BragDoc](/) to do. It extracts achievements from your GitHub activity automatically. When review time comes, you have a comprehensive record ready. Use AI writing tools to polish it, but start with complete input.
 

--- a/apps/marketing/content/blog/meta-ai-performance-reviews-missing-piece.mdx
+++ b/apps/marketing/content/blog/meta-ai-performance-reviews-missing-piece.mdx
@@ -1,0 +1,149 @@
+---
+title: "Meta Built an AI to Write Reviews. You Still Need to Remember."
+description: "Meta built an AI to help write performance reviews. But their system still requires you to manually input your accomplishments. Here's what they're missing."
+date: "2026-02-23"
+author: "BragDoc Team"
+tags: ["performance-reviews", "ai-tools", "meta", "achievement-tracking", "documentation"]
+image: "/images/blog/meta-ai-reviews/meta-ai-reviews-hero.svg"
+imageAlt: "Developer facing a blank performance review form despite having Meta's AI tools available"
+published: true
+canonical_url: "https://www.bragdoc.ai/blog/meta-ai-performance-reviews-missing-piece"
+---
+
+Late last year, Meta launched an AI-powered performance review assistant for their employees. The tool, which integrates their internal AI assistant Metamate with Google's Gemini, helps staff write better self-reviews and peer feedback.
+
+There's just one problem: you still have to tell it what you accomplished.
+
+The AI can make your writing more polished. It can format your achievements into compelling narratives. It can ensure your review aligns with company values. But it can't remember the critical bug fix you shipped in March. Or the architectural decision you made in July. Or the teammate you mentored in September.
+
+Meta's AI solves the output problem. It doesn't solve the input problem.
+
+## What Meta Actually Built
+
+In December 2025, Meta launched their AI Performance Assistant for year-end reviews. According to [Business Insider](https://www.businessinsider.com/meta-ai-assistant-helps-employees-performance-reviews-2025-11), the tool does exactly what you'd expect from a modern AI writing assistant.
+
+Employees feed their accomplishments into the system. The AI—using both Meta's internal Metamate (trained on company docs) and Google's Gemini—generates polished review text. Employees edit the output. Submit the review.
+
+Based on available reports, the workflow appears to work like this:
+
+1. Employee manually compiles what they worked on
+2. Employee inputs accomplishments into AI tool
+3. AI drafts review text
+4. Employee refines the AI-generated content
+5. Employee submits review
+
+Notice what's missing? Steps 0 through 1. The part where you actually remember what you did.
+
+## The Real Bottleneck in Performance Reviews
+
+If you've ever prepared a performance review, you know the hard part isn't writing eloquent prose. The hard part is answering a much simpler question: what did I actually accomplish in the last six months?
+
+You shipped code every day. You closed tickets. You reviewed PRs. You fixed bugs. You participated in design discussions. You mentored teammates. You made architectural decisions. All of this happened, but can you list it six months later?
+
+Most engineers can't. Not because they didn't do the work, but because human memory doesn't work that way.
+
+You remember the big projects. The feature launch that took three months. The incident that kept you up until 2am. But what about everything else? The steady stream of smaller contributions that actually make up most of your work?
+
+That refactor in April? Gone. The performance optimization in May? Fuzzy. The bug fix that saved a customer from churning? You know you did something like that, but when was it exactly?
+
+This is the documentation problem that Meta's AI doesn't solve. You can have the most sophisticated AI writing assistant in the world, but if you forget to mention the work in the first place, it never makes it into your review.
+
+## Meta's Approach Still Requires Manual Input
+
+Here's what Meta's AI Performance Assistant [actually does](https://www.businessinsider.com/meta-ai-assistant-helps-employees-performance-reviews-2025-11):
+
+**Metamate searches internal docs.** If you wrote design docs, sent emails, or posted in internal forums, Metamate can find and summarize those. That's useful for context.
+
+**It generates draft text.** Feed it bullet points about your work, and it'll turn them into polished review language. It knows company terminology. It can map your work to Meta's values.
+
+**It combines multiple AI models.** Using both Metamate and Gemini gives employees different strengths—internal context from one, broader reasoning from the other.
+
+But based on available information, it doesn't appear to automatically capture code commits, merged PRs, or closed bugs. Employees still need to tell the system what they accomplished.
+
+Even with access to internal documentation, the system still relies on you remembering what's worth documenting. If you didn't write a design doc for that critical bug fix, Metamate won't find it. If you didn't post about that architectural decision in the internal forum, it's not in the system.
+
+Your actual work—the code you shipped, the PRs you reviewed, the commits you made—isn't automatically captured.
+
+![Diagram showing what Metamate can access (internal docs, emails, forums) versus what it cannot access (Git commits, PRs, bugs, code reviews)](/images/blog/meta-ai-reviews/what-gets-missed.svg)
+
+## The Missing Layer: Automatic Achievement Capture
+
+This is where the automation gap becomes obvious. Meta employees still need to do the same thing everyone else does: manually compile their accomplishments before they can use the AI writing tool.
+
+Compare this to a system that starts with your actual work:
+
+1. Your Git commits are automatically captured as they happen
+2. PRs you created and merged are tracked
+3. Issues you closed are documented
+4. Technical context is preserved (branch names, commit messages, dates)
+5. When review time comes, you have a complete record
+
+This is what automatic achievement tracking provides. You're not relying on memory. You're not scrolling through six months of Git history at 11pm. The documentation already exists because it was captured while you were working.
+
+![Comparison diagram showing Meta's manual approach (remember, input, AI writes) versus automatic capture approach (work captured automatically, context preserved, complete record ready)](/images/blog/meta-ai-reviews/workflow-comparison.svg)
+
+Then—and only then—does an AI writing assistant become useful. It can help you synthesize that complete record into compelling review language. But it needs the complete record first.
+
+## Why This Matters Now
+
+Meta isn't just helping employees write reviews. They're changing how they evaluate them. Starting in 2026, ["AI-driven impact" becomes a formal part of performance reviews](https://www.businessinsider.com/meta-ai-assistant-helps-employees-performance-reviews-2025-11). Employees are assessed on how effectively they use AI tools to deliver results.
+
+This raises the stakes for documentation. It's not enough to say "I shipped features." You need to show how AI tools amplified your work. What did AI accelerate? Where did your strategic decisions matter most? What impact resulted from combining your judgment with AI capabilities?
+
+Answering these questions requires complete documentation of what you actually did. Not a partial list assembled from memory. Not the big projects you remember plus a few smaller ones you happened to write down.
+
+The complete record. Every contribution. Every decision. Every outcome.
+
+## What Meta Got Right (And What They Missed)
+
+Meta deserves credit for recognizing that AI can improve the performance review process. Writing clear, compelling self-reviews is hard, and an AI assistant helps. The multi-model approach—combining their internal Metamate with external models like Gemini—is smart architecture.
+
+But they solved the wrong bottleneck. The hard part isn't writing polished prose. It's remembering what you accomplished in the first place.
+
+Put differently: Meta built a better typewriter when what employees needed was a better notebook.
+
+## What Actually Solves This
+
+The solution isn't better AI writing. It's automatic capture.
+
+Your Git history already contains a complete record of your technical work. Every commit. Every PR. Every code review. Timestamped. With context. With diffs showing exactly what changed.
+
+This is objective documentation that requires zero additional effort. You create it automatically every time you push code.
+
+The problem isn't the data—it's extracting meaningful achievements from it. That's where [automated achievement tracking](/blog/why-developers-need-automated-brag-docs) changes the equation.
+
+Instead of manually compiling your work six months later, the system processes your Git history continuously. As you work. Commit by commit. PR by PR. When review time comes, you have a comprehensive list of what you actually accomplished.
+
+That's when an AI writing assistant becomes truly valuable. It can help you synthesize that complete record into compelling review language. But it needs the input first.
+
+## The Shift to AI-Driven Performance Reviews
+
+Meta's move signals where the industry is heading. Other companies will follow. [AI-driven impact](/blog/documenting-impact-ai-coding-era) will become a standard evaluation criterion.
+
+This makes comprehensive documentation even more critical. You'll need to show:
+
+- What problems you solved
+- How you used AI to amplify your work
+- Where your strategic decisions mattered
+- What impact resulted
+- How you enabled others to do better work
+
+You can't demonstrate any of this if you forgot half your accomplishments. The engineers who thrive in this environment will be the ones with complete achievement records. Not because they're better self-promoters. Because they have better systems.
+
+## Start With Better Input
+
+Meta built an AI to help write performance reviews. But the real leverage comes earlier: automatic capture while you work.
+
+Then use AI to polish the writing. Start with complete data. Everything else is trying to write a good story about work you forgot you did.
+
+## Where to Go From Here
+
+If you're using Meta's AI Performance Assistant—or any similar tool—make sure you're feeding it complete information. The AI can only work with what you give it.
+
+That means capturing your work continuously. Git commits, PRs you created, issues you closed—all documented as it happens.
+
+That's what we built [BragDoc](/) to do. It extracts achievements from your GitHub activity automatically. When review time comes, you have a comprehensive record ready. Use AI writing tools to polish it, but start with complete input.
+
+Meta built AI to help employees write reviews. You can solve the harder problem—remembering what to write—by capturing your Git history. Your actual work is already documented. It's time to use it.
+
+<SignUpCTA />

--- a/apps/marketing/public/images/blog/duolingo-ai-reversal/duolingo-ai-reversal-hero.svg
+++ b/apps/marketing/public/images/blog/duolingo-ai-reversal/duolingo-ai-reversal-hero.svg
@@ -1,0 +1,100 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#0F172A"/>
+
+  <!-- Grid pattern -->
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1E293B" stroke-width="1"/>
+    </pattern>
+    <linearGradient id="leftGlow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#EF4444;stop-opacity:0.15" />
+      <stop offset="100%" style="stop-color:#EF4444;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient id="rightGlow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#10B981;stop-opacity:0" />
+      <stop offset="100%" style="stop-color:#10B981;stop-opacity:0.15" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.4"/>
+
+  <!-- Left glow -->
+  <rect x="0" y="0" width="550" height="630" fill="url(#leftGlow)"/>
+  <!-- Right glow -->
+  <rect x="650" y="0" width="550" height="630" fill="url(#rightGlow)"/>
+
+  <!-- Divider line -->
+  <line x1="600" y1="80" x2="600" y2="580" stroke="#334155" stroke-width="1" stroke-dasharray="6 4"/>
+
+  <!-- Title -->
+  <text x="600" y="55" font-family="system-ui, -apple-system, sans-serif" font-size="32" font-weight="700" fill="#F1F5F9" text-anchor="middle">The AI Performance Review Divide</text>
+
+  <!-- LEFT SIDE — Duolingo reverses -->
+  <text x="300" y="115" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#EF4444" text-anchor="middle">Duolingo</text>
+  <text x="300" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#94A3B8" text-anchor="middle">BACKED DOWN</text>
+
+  <!-- Duolingo card -->
+  <rect x="80" y="160" width="440" height="320" rx="12" fill="#1E293B" stroke="#EF4444" stroke-width="1.5" stroke-opacity="0.6"/>
+
+  <!-- Policy text strikethrough -->
+  <text x="300" y="205" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#94A3B8" text-anchor="middle">Original policy (April 2025):</text>
+  <text x="300" y="232" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#64748B" text-anchor="middle">"Employees evaluated on AI usage"</text>
+  <line x1="130" y1="230" x2="470" y2="230" stroke="#EF4444" stroke-width="2" opacity="0.8"/>
+
+  <!-- Reversed label -->
+  <rect x="200" y="255" width="200" height="32" rx="6" fill="#EF4444" fill-opacity="0.15" stroke="#EF4444" stroke-width="1"/>
+  <text x="300" y="276" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#EF4444" text-anchor="middle">↩ Reversed April 2026</text>
+
+  <!-- CEO quote -->
+  <text x="300" y="325" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#94A3B8" text-anchor="middle">"If AI can't help you do your job better,</text>
+  <text x="300" y="345" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#94A3B8" text-anchor="middle">I'm not going to force you."</text>
+  <text x="300" y="368" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">— Luis von Ahn, CEO, Duolingo</text>
+
+  <!-- Reasons -->
+  <text x="300" y="410" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748B" text-anchor="middle">Employee pushback · User backlash</text>
+  <text x="300" y="430" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#64748B" text-anchor="middle">Public pressure</text>
+
+  <!-- X mark -->
+  <circle cx="300" cy="465" r="20" fill="#EF4444" fill-opacity="0.15" stroke="#EF4444" stroke-width="1.5"/>
+  <line x1="291" y1="456" x2="309" y2="474" stroke="#EF4444" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="309" y1="456" x2="291" y2="474" stroke="#EF4444" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- RIGHT SIDE — Meta/Amazon/Google double down -->
+  <text x="900" y="115" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#10B981" text-anchor="middle">Meta · Amazon · Google</text>
+  <text x="900" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#94A3B8" text-anchor="middle">DOUBLED DOWN</text>
+
+  <!-- Companies card -->
+  <rect x="680" y="160" width="440" height="320" rx="12" fill="#1E293B" stroke="#10B981" stroke-width="1.5" stroke-opacity="0.6"/>
+
+  <!-- Meta row -->
+  <rect x="700" y="178" width="400" height="80" rx="8" fill="#0F172A" fill-opacity="0.6"/>
+  <text x="720" y="201" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#F1F5F9">Meta — Checkpoint</text>
+  <text x="720" y="220" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">200+ signals: AI code, velocity, strategic decisions</text>
+  <text x="720" y="238" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#10B981">AI-driven impact tied to compensation</text>
+  <circle cx="1065" cy="218" r="10" fill="#10B981" fill-opacity="0.2" stroke="#10B981" stroke-width="1"/>
+  <path d="M1059 218 L1063 222 L1071 213" stroke="#10B981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+
+  <!-- Amazon row -->
+  <rect x="700" y="268" width="400" height="80" rx="8" fill="#0F172A" fill-opacity="0.6"/>
+  <text x="720" y="291" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#F1F5F9">Amazon — Forte</text>
+  <text x="720" y="310" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">3–5 documented accomplishments required per cycle</text>
+  <text x="720" y="328" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#10B981">Pay and equity tied to documented output</text>
+  <circle cx="1065" cy="308" r="10" fill="#10B981" fill-opacity="0.2" stroke="#10B981" stroke-width="1"/>
+  <path d="M1059 308 L1063 312 L1071 303" stroke="#10B981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+
+  <!-- Google row -->
+  <rect x="700" y="358" width="400" height="80" rx="8" fill="#0F172A" fill-opacity="0.6"/>
+  <text x="720" y="381" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#F1F5F9">Google — GRAD</text>
+  <text x="720" y="400" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">Recalibrated: tighter top ratings, annual only</text>
+  <text x="720" y="418" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#10B981">High performers rewarded, rest squeezed</text>
+  <circle cx="1065" cy="398" r="10" fill="#10B981" fill-opacity="0.2" stroke="#10B981" stroke-width="1"/>
+  <path d="M1059 398 L1063 402 L1071 393" stroke="#10B981" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+
+  <!-- Forward arrow -->
+  <circle cx="900" cy="465" r="20" fill="#10B981" fill-opacity="0.15" stroke="#10B981" stroke-width="1.5"/>
+  <path d="M888 465 L907 465" stroke="#10B981" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M901 458 L908 465 L901 472" stroke="#10B981" stroke-width="2.5" stroke-linecap="round" fill="none"/>
+
+  <!-- Bottom tagline -->
+  <text x="600" y="570" font-family="system-ui, -apple-system, sans-serif" font-size="15" fill="#64748B" text-anchor="middle">Your company may not force AI. But it will measure what you produce with it. Document everything.</text>
+</svg>

--- a/apps/marketing/public/images/blog/meta-ai-reviews/meta-ai-reviews-hero.svg
+++ b/apps/marketing/public/images/blog/meta-ai-reviews/meta-ai-reviews-hero.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400">
+  <!-- Background -->
+  <rect width="800" height="400" fill="#f8fafc"/>
+
+  <!-- Developer at desk -->
+  <g id="developer">
+    <!-- Desk -->
+    <rect x="50" y="280" width="300" height="8" fill="#64748b" rx="2"/>
+
+    <!-- Laptop -->
+    <rect x="100" y="220" width="200" height="120" fill="#1e293b" rx="4"/>
+    <rect x="110" y="230" width="180" height="90" fill="#0f172a"/>
+
+    <!-- Screen content - blank review form -->
+    <rect x="120" y="240" width="160" height="8" fill="#475569" rx="2"/>
+    <rect x="120" y="255" width="120" height="6" fill="#334155" rx="2"/>
+    <rect x="120" y="268" width="160" height="30" fill="#1e293b" stroke="#475569" stroke-width="1" rx="2"/>
+    <text x="200" y="288" font-family="Arial, sans-serif" font-size="10" fill="#64748b" text-anchor="middle">???</text>
+
+    <!-- Person head -->
+    <circle cx="200" cy="200" r="25" fill="#94a3b8"/>
+
+    <!-- Confused expression -->
+    <circle cx="192" cy="195" r="3" fill="#1e293b"/>
+    <circle cx="208" cy="195" r="3" fill="#1e293b"/>
+    <path d="M 185 208 Q 200 212 215 208" stroke="#1e293b" stroke-width="2" fill="none"/>
+
+    <!-- Thought bubble -->
+    <ellipse cx="250" cy="160" rx="80" ry="50" fill="#fff" stroke="#94a3b8" stroke-width="2"/>
+    <circle cx="225" cy="185" r="8" fill="#fff" stroke="#94a3b8" stroke-width="2"/>
+    <circle cx="215" cy="195" r="5" fill="#fff" stroke="#94a3b8" stroke-width="2"/>
+
+    <!-- Text in thought bubble -->
+    <text x="250" y="155" font-family="Arial, sans-serif" font-size="12" fill="#475569" text-anchor="middle">What did I do</text>
+    <text x="250" y="170" font-family="Arial, sans-serif" font-size="12" fill="#475569" text-anchor="middle">in March?</text>
+  </g>
+
+  <!-- AI assistant icon -->
+  <g id="ai-assistant">
+    <!-- Floating AI chip -->
+    <rect x="450" y="150" width="280" height="140" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="8"/>
+
+    <!-- AI sparkle icon -->
+    <circle cx="490" cy="190" r="20" fill="#8b5cf6" opacity="0.2"/>
+    <path d="M 490 175 L 493 187 L 505 190 L 493 193 L 490 205 L 487 193 L 475 190 L 487 187 Z" fill="#8b5cf6"/>
+
+    <!-- Text -->
+    <text x="525" y="185" font-family="Arial, sans-serif" font-size="16" fill="#1e293b" font-weight="bold">AI Writing Assistant</text>
+    <text x="525" y="205" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Ready to help you write</text>
+    <text x="525" y="220" font-family="Arial, sans-serif" font-size="12" fill="#64748b">your review...</text>
+
+    <!-- Question mark -->
+    <text x="680" y="265" font-family="Arial, sans-serif" font-size="48" fill="#94a3b8" opacity="0.3">?</text>
+  </g>
+
+  <!-- Gap indicator -->
+  <g id="gap">
+    <line x1="350" y1="240" x2="450" y2="220" stroke="#ef4444" stroke-width="3" stroke-dasharray="5,5"/>
+    <text x="400" y="220" font-family="Arial, sans-serif" font-size="14" fill="#ef4444" font-weight="bold" text-anchor="middle">The Gap</text>
+  </g>
+
+  <!-- Title text -->
+  <text x="400" y="360" font-family="Arial, sans-serif" font-size="18" fill="#475569" text-anchor="middle" font-style="italic">You still need to remember what you accomplished</text>
+</svg>

--- a/apps/marketing/public/images/blog/meta-ai-reviews/what-gets-missed.svg
+++ b/apps/marketing/public/images/blog/meta-ai-reviews/what-gets-missed.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450">
+  <!-- Background -->
+  <rect width="800" height="450" fill="#f8fafc"/>
+
+  <!-- Title -->
+  <text x="400" y="35" font-family="Arial, sans-serif" font-size="20" fill="#1e293b" font-weight="bold" text-anchor="middle">What Meta's AI Can and Can't See</text>
+
+  <!-- Left side - What it CAN see -->
+  <g id="can-see">
+    <rect x="50" y="70" width="320" height="340" fill="#f0fdf4" stroke="#22c55e" stroke-width="2" rx="8"/>
+
+    <!-- Header -->
+    <circle cx="210" cy="105" r="25" fill="#22c55e"/>
+    <path d="M 200 105 L 207 112 L 222 97" stroke="#fff" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <text x="210" y="165" font-family="Arial, sans-serif" font-size="16" fill="#166534" font-weight="bold" text-anchor="middle">Metamate CAN Access</text>
+
+    <!-- Items -->
+    <g transform="translate(70, 190)">
+      <!-- Doc item -->
+      <rect width="280" height="40" fill="#fff" stroke="#d1fae5" stroke-width="1" rx="4"/>
+      <rect x="10" y="10" width="24" height="20" fill="#86efac" rx="2"/>
+      <line x1="16" y1="17" x2="28" y2="17" stroke="#fff" stroke-width="2"/>
+      <line x1="16" y1="22" x2="28" y2="22" stroke="#fff" stroke-width="2"/>
+      <text x="45" y="25" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Design docs you wrote</text>
+
+      <!-- Email item -->
+      <rect y="50" width="280" height="40" fill="#fff" stroke="#d1fae5" stroke-width="1" rx="4"/>
+      <rect x="10" y="60" width="24" height="20" fill="#86efac" rx="2"/>
+      <text x="20" y="75" font-family="Arial, sans-serif" font-size="16" fill="#fff">@</text>
+      <text x="45" y="75" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Internal emails you sent</text>
+
+      <!-- Forum item -->
+      <rect y="100" width="280" height="40" fill="#fff" stroke="#d1fae5" stroke-width="1" rx="4"/>
+      <rect x="10" y="110" width="24" height="20" fill="#86efac" rx="2"/>
+      <circle cx="22" cy="120" r="6" fill="#fff"/>
+      <circle cx="22" cy="120" r="3" fill="#86efac"/>
+      <text x="45" y="125" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Forum posts you made</text>
+
+      <!-- Project notes -->
+      <rect y="150" width="280" height="40" fill="#fff" stroke="#d1fae5" stroke-width="1" rx="4"/>
+      <rect x="10" y="160" width="24" height="20" fill="#86efac" rx="2"/>
+      <path d="M 16 167 L 20 171 L 28 163" stroke="#fff" stroke-width="2" fill="none"/>
+      <text x="45" y="175" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Project notes in wikis</text>
+    </g>
+
+    <text x="210" y="395" font-family="Arial, sans-serif" font-size="12" fill="#166534" text-anchor="middle" font-style="italic">If you documented it</text>
+  </g>
+
+  <!-- Right side - What it CANNOT see -->
+  <g id="cannot-see">
+    <rect x="430" y="70" width="320" height="340" fill="#fef2f2" stroke="#ef4444" stroke-width="2" rx="8"/>
+
+    <!-- Header -->
+    <circle cx="590" cy="105" r="25" fill="#ef4444"/>
+    <line x1="580" y1="95" x2="600" y2="115" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+    <line x1="600" y1="95" x2="580" y2="115" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+    <text x="590" y="165" font-family="Arial, sans-serif" font-size="16" fill="#991b1b" font-weight="bold" text-anchor="middle">Metamate CANNOT See</text>
+
+    <!-- Items -->
+    <g transform="translate(450, 190)">
+      <!-- Git commits -->
+      <rect width="280" height="40" fill="#fff" stroke="#fecaca" stroke-width="1" rx="4"/>
+      <rect x="10" y="10" width="24" height="20" fill="#fca5a5" rx="2"/>
+      <text x="20" y="25" font-family="monospace" font-size="14" fill="#fff" font-weight="bold">&lt;/&gt;</text>
+      <text x="45" y="25" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Git commits you made</text>
+
+      <!-- PRs -->
+      <rect y="50" width="280" height="40" fill="#fff" stroke="#fecaca" stroke-width="1" rx="4"/>
+      <rect x="10" y="60" width="24" height="20" fill="#fca5a5" rx="2"/>
+      <path d="M 16 70 L 28 70 M 16 70 L 20 66 M 16 70 L 20 74" stroke="#fff" stroke-width="2"/>
+      <text x="45" y="75" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">PRs you merged</text>
+
+      <!-- Bugs fixed -->
+      <rect y="100" width="280" height="40" fill="#fff" stroke="#fecaca" stroke-width="1" rx="4"/>
+      <rect x="10" y="110" width="24" height="20" fill="#fca5a5" rx="2"/>
+      <circle cx="22" cy="120" r="6" stroke="#fff" stroke-width="2" fill="none"/>
+      <line x1="22" y1="114" x2="22" y2="126" stroke="#fff" stroke-width="2"/>
+      <text x="45" y="125" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Bugs you fixed</text>
+
+      <!-- Code reviews -->
+      <rect y="150" width="280" height="40" fill="#fff" stroke="#fecaca" stroke-width="1" rx="4"/>
+      <rect x="10" y="160" width="24" height="20" fill="#fca5a5" rx="2"/>
+      <circle cx="19" cy="170" r="4" fill="#fff"/>
+      <circle cx="25" cy="170" r="4" fill="#fff"/>
+      <text x="45" y="175" font-family="Arial, sans-serif" font-size="13" fill="#1e293b">Code reviews you did</text>
+    </g>
+
+    <text x="590" y="395" font-family="Arial, sans-serif" font-size="12" fill="#991b1b" text-anchor="middle" font-style="italic">Your actual code work</text>
+  </g>
+
+  <!-- Bottom note -->
+  <text x="400" y="435" font-family="Arial, sans-serif" font-size="14" fill="#64748b" text-anchor="middle">Without automatic capture, most technical work never makes it into your review</text>
+</svg>

--- a/apps/marketing/public/images/blog/meta-ai-reviews/workflow-comparison.svg
+++ b/apps/marketing/public/images/blog/meta-ai-reviews/workflow-comparison.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500">
+  <!-- Background -->
+  <rect width="900" height="500" fill="#f8fafc"/>
+
+  <!-- Title -->
+  <text x="450" y="35" font-family="Arial, sans-serif" font-size="20" fill="#1e293b" font-weight="bold" text-anchor="middle">Two Approaches to Performance Reviews</text>
+
+  <!-- Left side - Meta's Approach -->
+  <g id="meta-approach">
+    <!-- Header -->
+    <rect x="50" y="60" width="360" height="40" fill="#8b5cf6" rx="6"/>
+    <text x="230" y="88" font-family="Arial, sans-serif" font-size="18" fill="#fff" font-weight="bold" text-anchor="middle">Meta's AI Assistant</text>
+
+    <!-- Step 1 - Manual Input -->
+    <rect x="70" y="130" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="100" cy="160" r="18" fill="#ef4444" opacity="0.2"/>
+    <text x="100" y="167" font-family="Arial, sans-serif" font-size="16" fill="#ef4444" font-weight="bold" text-anchor="middle">1</text>
+    <text x="140" y="158" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">You manually remember</text>
+    <text x="140" y="178" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Recall 6 months of work</text>
+    <text x="140" y="194" font-family="Arial, sans-serif" font-size="12" fill="#64748b">from memory</text>
+
+    <!-- Arrow -->
+    <path d="M 230 210 L 230 235" stroke="#cbd5e1" stroke-width="2" marker-end="url(#arrowgray)"/>
+
+    <!-- Step 2 - Type it in -->
+    <rect x="70" y="245" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="100" cy="275" r="18" fill="#ef4444" opacity="0.2"/>
+    <text x="100" y="282" font-family="Arial, sans-serif" font-size="16" fill="#ef4444" font-weight="bold" text-anchor="middle">2</text>
+    <text x="140" y="273" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">Manually input to AI</text>
+    <text x="140" y="293" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Type accomplishments</text>
+    <text x="140" y="309" font-family="Arial, sans-serif" font-size="12" fill="#64748b">you remembered</text>
+
+    <!-- Arrow -->
+    <path d="M 230 325 L 230 350" stroke="#cbd5e1" stroke-width="2" marker-end="url(#arrowgray)"/>
+
+    <!-- Step 3 - AI writes -->
+    <rect x="70" y="360" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="100" cy="390" r="18" fill="#8b5cf6" opacity="0.2"/>
+    <text x="100" y="397" font-family="Arial, sans-serif" font-size="16" fill="#8b5cf6" font-weight="bold" text-anchor="middle">3</text>
+    <text x="140" y="388" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">AI polishes writing</text>
+    <text x="140" y="408" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Generates review text</text>
+    <text x="140" y="424" font-family="Arial, sans-serif" font-size="12" fill="#64748b">from your input</text>
+  </g>
+
+  <!-- Right side - BragDoc Approach -->
+  <g id="bragdoc-approach">
+    <!-- Header -->
+    <rect x="490" y="60" width="360" height="40" fill="#10b981" rx="6"/>
+    <text x="670" y="88" font-family="Arial, sans-serif" font-size="18" fill="#fff" font-weight="bold" text-anchor="middle">BragDoc Automatic Capture</text>
+
+    <!-- Step 1 - Automatic capture -->
+    <rect x="510" y="130" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="540" cy="160" r="18" fill="#10b981" opacity="0.2"/>
+    <text x="540" y="167" font-family="Arial, sans-serif" font-size="16" fill="#10b981" font-weight="bold" text-anchor="middle">1</text>
+    <text x="580" y="158" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">Work automatically captured</text>
+    <text x="580" y="178" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Git commits, PRs, issues</text>
+    <text x="580" y="194" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tracked as they happen</text>
+
+    <!-- Arrow -->
+    <path d="M 670 210 L 670 235" stroke="#cbd5e1" stroke-width="2" marker-end="url(#arrowgray)"/>
+
+    <!-- Step 2 - Context preserved -->
+    <rect x="510" y="245" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="540" cy="275" r="18" fill="#10b981" opacity="0.2"/>
+    <text x="540" y="282" font-family="Arial, sans-serif" font-size="16" fill="#10b981" font-weight="bold" text-anchor="middle">2</text>
+    <text x="580" y="273" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">Context preserved</text>
+    <text x="580" y="293" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Dates, details, metrics</text>
+    <text x="580" y="309" font-family="Arial, sans-serif" font-size="12" fill="#64748b">all automatically saved</text>
+
+    <!-- Arrow -->
+    <path d="M 670 325 L 670 350" stroke="#cbd5e1" stroke-width="2" marker-end="url(#arrowgray)"/>
+
+    <!-- Step 3 - Complete record -->
+    <rect x="510" y="360" width="320" height="80" fill="#fff" stroke="#e2e8f0" stroke-width="2" rx="6"/>
+    <circle cx="540" cy="390" r="18" fill="#10b981" opacity="0.2"/>
+    <text x="540" y="397" font-family="Arial, sans-serif" font-size="16" fill="#10b981" font-weight="bold" text-anchor="middle">3</text>
+    <text x="580" y="388" font-family="Arial, sans-serif" font-size="14" fill="#1e293b" font-weight="bold">Review with confidence</text>
+    <text x="580" y="408" font-family="Arial, sans-serif" font-size="12" fill="#64748b">Complete achievement list</text>
+    <text x="580" y="424" font-family="Arial, sans-serif" font-size="12" fill="#64748b">ready when you need it</text>
+  </g>
+
+  <!-- Bottom comparison -->
+  <g id="comparison">
+    <rect x="70" y="460" width="320" height="20" fill="#fef2f2"/>
+    <text x="230" y="474" font-family="Arial, sans-serif" font-size="11" fill="#991b1b" text-anchor="middle">Relies on memory</text>
+
+    <rect x="510" y="460" width="320" height="20" fill="#f0fdf4"/>
+    <text x="670" y="474" font-family="Arial, sans-serif" font-size="11" fill="#166534" text-anchor="middle">Nothing forgotten</text>
+  </g>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="arrowgray" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 Z" fill="#cbd5e1"/>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary

New blog post covering the April 2026 Duolingo reversal on AI performance review policy.

**Unique angle:** The key distinction between mandating AI *tool adoption* (Duolingo backed down) vs. mandating documented *output* (Meta, Amazon, Google doubled down). Argues the lesson isn't that companies are softening on AI reviews — it's that you can't mandate a tool but you can mandate a result.

**What's included:**
- Hero SVG (dark split-screen: Duolingo reversal vs. competitors doubling down)
- External citations: Fortune, HR Grapevine, CNBC
- Internal cross-links to existing posts to avoid repeating covered content

## Test plan

- [ ] Post renders at `/blog/duolingo-reversed-ai-reviews-competitors-doubled-down`
- [ ] Hero image displays in blog listing card
- [ ] Internal links resolve correctly
- [ ] External source links present

🤖 Generated with [Claude Code](https://claude.com/claude-code)