### PR TITLE
fix: ImageGallery crash when images prop is undefined (blocks all deploys)

### DIFF
--- a/apps/marketing/components/image-gallery.tsx
+++ b/apps/marketing/components/image-gallery.tsx
@@ -15,7 +15,7 @@ interface ImageGalleryProps {
 }
 
 export function ImageGallery({
-  images,
+  images = [],
   height = 300,
   gap = 8,
   fullWidth = false,


### PR DESCRIPTION
## Problem

The marketing site has been failing to build/deploy since the `next-mdx-remote` v5→v6 upgrade. The build crashes on `/blog/manager-ammunition-documentation` with:

```
TypeError: Cannot read properties of undefined (reading 'map')
```

`next-mdx-remote` v6 RSC mode can pass component props as `undefined`. The `ImageGallery` component calls `images.map()` directly with no default value, causing a crash when `images` is undefined.

This has been blocking **all** Vercel production deployments.

## Fix

One-line fix: default `images` to `[]` in the destructured props.

```tsx
// Before
export function ImageGallery({ images, ... })

// After  
export function ImageGallery({ images = [], ... })
```

## Test

Build passes locally: `pnpm build:marketing` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)