### PR TITLE
fix: scope recent-achievements query by userId (cross-tenant data leak)

### DIFF
--- a/apps/web/app/api/dashboard/recent-achievements/route.ts
+++ b/apps/web/app/api/dashboard/recent-achievements/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/getAuthUser';
 import { db } from '@/database/index';
 import { achievement, project, company } from '@/database/schema';
-import { eq, desc } from 'drizzle-orm';
+import { and, eq, desc } from 'drizzle-orm';
 
 export async function GET(request: NextRequest) {
   try {
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
       .leftJoin(project, eq(achievement.projectId, project.id))
       .leftJoin(company, eq(achievement.companyId, company.id))
       .where(
-        eq(achievement.userId, userId) && eq(achievement.isArchived, false),
+        and(eq(achievement.userId, userId), eq(achievement.isArchived, false)),
       )
       .orderBy(desc(achievement.createdAt))
       .limit(10);


### PR DESCRIPTION
## Security fix — CRITICAL

The dashboard **recent-achievements** endpoint leaks every user's achievements to any authenticated user.

### Root cause
`apps/web/app/api/dashboard/recent-achievements/route.ts` combined its filters with JavaScript `&&` instead of Drizzle's `and()`:

```ts
.where(eq(achievement.userId, userId) && eq(achievement.isArchived, false))
```

`eq()` returns a truthy query-fragment object, so `truthy && expr` evaluates to **only the right-hand operand**. The effective query was `WHERE isArchived = false` — no user scoping. The endpoint returned the 10 most-recent achievements **across all users** (title, summary, impact, project, company) on every dashboard load.

The `if (!userId || userId !== user.id)` guard above only validates the query-string parameter; the DB query ignored it entirely, so the check gave a false sense of safety.

### Fix
Use `and()` so both predicates apply:

```ts
.where(and(eq(achievement.userId, userId), eq(achievement.isArchived, false)))
```

### Scope check
Grepped the codebase for the same bug class (`&&` between Drizzle operators inside a `.where()`) — this was the **only** occurrence.

### Notes
- No preconditions to exploit; fires on normal dashboard use.
- Found during a full security review; see `SECURITY-REVIEW.md` (finding CRIT-2). Consider a lint rule to ban `&&` inside Drizzle `.where(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)